### PR TITLE
WIP: Delegation REST Endpoints

### DIFF
--- a/cmd/gaia/rest.go
+++ b/cmd/gaia/rest.go
@@ -63,6 +63,7 @@ func cmdRestServer(cmd *cobra.Command, args []string) error {
 
 		//staking query functionality TODO add tx and all query here
 		stakerest.RegisterQueryCandidate,
+		stakerest.RegisterQueryCandidates,
 		stakerest.RegisterDelegate,
 	}
 

--- a/cmd/gaia/rest.go
+++ b/cmd/gaia/rest.go
@@ -61,10 +61,12 @@ func cmdRestServer(cmd *cobra.Command, args []string) error {
 		// Nonce query handler
 		noncerest.RegisterQueryNonce,
 
-		//staking query functionality TODO add tx and all query here
+		// Staking query handlers
 		stakerest.RegisterQueryCandidate,
 		stakerest.RegisterQueryCandidates,
+		// Staking tx builders
 		stakerest.RegisterDelegate,
+		stakerest.RegisterUnbond,
 	}
 
 	for _, routeRegistrar := range routeRegistrars {

--- a/cmd/gaia/rest.go
+++ b/cmd/gaia/rest.go
@@ -63,6 +63,7 @@ func cmdRestServer(cmd *cobra.Command, args []string) error {
 
 		//staking query functionality TODO add tx and all query here
 		stakerest.RegisterQueryCandidate,
+		stakerest.RegisterDelegate,
 	}
 
 	for _, routeRegistrar := range routeRegistrars {

--- a/modules/stake/rest/query.go
+++ b/modules/stake/rest/query.go
@@ -22,14 +22,14 @@ import (
 // RegisterQueryCandidate is a mux.Router handler that exposes GET
 // method access on route /query/stake/candidate/{pubkey} to query a candidate
 func RegisterQueryCandidate(r *mux.Router) error {
-	r.HandleFunc("/query/stake/candidate/{pubkey}", queryCandidate).Methods("GET")
+	r.HandleFunc("/query/stake/candidates/{pubkey}", queryCandidate).Methods("GET")
 	return nil
 }
 
 // RegisterQueryCandidates is a mux.Router handler that exposes GET
 // method access on route /query/stake/candidate to query the group of all candidates
 func RegisterQueryCandidates(r *mux.Router) error {
-	r.HandleFunc("/query/stake/candidate", queryCandidates).Methods("GET")
+	r.HandleFunc("/query/stake/candidates", queryCandidates).Methods("GET")
 	return nil
 }
 


### PR DESCRIPTION
Don't merge this yet, still need to finish the other endpoints. So far I've added the `DelegateTx` builder (`POST /build/stake/delegate`).

You can test it out by building this branch, running `gaia rest-server`, then making a request:
```bash
curl -d '{
  "from": {"chain":"","app":"sigs","addr":""},
  "sequence":1,
  "amount": {"denom":"fermion","amount":123},
  "pubkey": {
    "type": "ed25519",
    "data": "4475505E90626E03AC3D653CC498E71A2DCC4E2D9BB451A21E30018E723D1D05"
  }
}' localhost:8998/build/stake/delegate
```