### PR TITLE
Fixes gaia/modules/stake [build failed] errors

### DIFF
--- a/modules/stake/errors.go
+++ b/modules/stake/errors.go
@@ -13,7 +13,7 @@ var (
 	errBadBondingAmount   = fmt.Errorf("Amount must be > 0")
 	errNoBondingAcct      = fmt.Errorf("No bond account for this (address, validator) pair")
 	errCommissionNegative = fmt.Errorf("Commission must be positive")
-	errCommissionHuge     = fmt.Errorf("Commission cannot be more than 100%")
+	errCommissionHuge     = fmt.Errorf("Commission cannot be more than 100%%")
 
 	errBadValidatorAddr      = fmt.Errorf("Validator does not exist for that address")
 	errCandidateExistsAddr   = fmt.Errorf("Candidate already exist, cannot re-declare candidacy")


### PR DESCRIPTION
## Producing:
```
go get github.com/cosmos/gaia
cd $GOPATH/src/github.com/cosmos/gaia
git checkout develop
make all
...
...
...
[INFO]	--> Exporting gopkg.in/go-playground/validator.v9
[INFO]	Replacing existing vendor dependencies
go install ./cmd/gaia
# github.com/cosmos/gaia/modules/stake
modules/stake/errors.go:16: Errorf format % is missing verb at end of string
FAIL	github.com/cosmos/gaia/modules/stake [build failed]
?   	github.com/cosmos/gaia/modules/stake/commands	[no test files]
?   	github.com/cosmos/gaia/modules/stake/rest	[no test files]
?   	github.com/cosmos/gaia/cmd/gaia	[no test files]
?   	github.com/cosmos/gaia/version	[no test files]
Makefile:11: recipe for target 'test' failed
make: *** [test] Error 2
```
## Resolving:
[hdr-Printing](https://golang.org/pkg/fmt/#hdr-Printing)
Just add another `%`.

----

@ebuchman @zramsay @adrianbrink 