### PR TITLE
Various buildsystem fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
-GOBIN ?= $(GOPATH)/bin
 
 export GO111MODULE = on
 
@@ -116,12 +115,14 @@ distclean: clean
 ### Testing
 
 
-check: check-unit
+check: check-unit check-build
+check-all: check check-race check-cover
+
 check-unit:
-	@VERSION=$(VERSION) go test -mod=readonly -race -tags='ledger test_ledger_mock' ./...
+	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock' ./...
 
 check-race:
-	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock' -race ./...
+	@VERSION=$(VERSION) go test -mod=readonly -race -tags='ledger test_ledger_mock' ./...
 
 check-cover:
 	@go test -mod=readonly -timeout 30m -race -coverprofile=coverage.txt -covermode=atomic -tags='ledger test_ledger_mock' ./...
@@ -129,7 +130,6 @@ check-cover:
 check-build: build
 	@go test -mod=readonly -p 4 `go list ./cli_test/...` -tags=cli_test
 
-check-all: check-unit check-race check-cover check-build
 
 lint: ci-lint
 ci-lint:

--- a/cli_test/test_helpers.go
+++ b/cli_test/test_helpers.go
@@ -88,7 +88,7 @@ func NewFixtures(t *testing.T) *Fixtures {
 
 	buildDir := os.Getenv("BUILDDIR")
 	if buildDir == "" {
-		buildDir, err = filepath.Abs("../../../build/")
+		buildDir, err = filepath.Abs("../build/")
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Makefile:
- Remove GOBIN, it's unnecessary and breaks cross-compilation.
- Run integration tests by default when running make.
- Don't enable race conditions detection when running make check-unit.
  We have check-race for that.

cli_test/test_helpers.go:
- Fix default build directory for integraion tests.

------------------

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
