### PR TITLE
Various updates to tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,6 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run:
-          name: tools
-          command: |
-            make tools TOOLS_DESTDIR=/tmp/workspace/bin
-            cp $GOPATH/bin/runsim /tmp/workspace/bin/
-      - run:
           name: binaries
           command: |
             export PATH=/tmp/workspace/bin:$PATH
@@ -64,27 +59,16 @@ jobs:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+      - run:
+          name: tools
+          command: |
+            make tools TOOLS_DESTDIR=/tmp/workspace/bin
+            cp $GOPATH/bin/runsim /tmp/workspace/bin/
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
             - bin
             - profiles
-
-  lint:
-    <<: *linux_defaults
-    parallelism: 1
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
-      - run:
-          name: Lint source
-          command: |
-            export PATH=/tmp/workspace/bin:$PATH
-            make ci-lint
 
   integration_tests:
     <<: *linux_defaults
@@ -447,9 +431,6 @@ workflows:
             tags:
               only:
                 - /^v.*/
-      - lint:
-          requires:
-            - setup_dependencies
       - integration_tests:
           requires:
             - setup_dependencies

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,7 @@ check-build: build
 	@go test -mod=readonly -p 4 `go list ./cli_test/...` -tags=cli_test
 
 
-lint: ci-lint
-ci-lint:
+lint: golangci-lint
 	golangci-lint run
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
 	go mod verify

--- a/contrib/devtools/Makefile
+++ b/contrib/devtools/Makefile
@@ -17,8 +17,8 @@ endif
 
 GOPATH ?= $(shell $(GO) env GOPATH)
 GITHUBDIR := $(GOPATH)$(FS)src$(FS)github.com
-GOLANGCI_LINT_VERSION := v1.16.0
-GOLANGCI_LINT_HASHSUM := ac897cadc180bf0c1a4bf27776c410debad27205b22856b861d41d39d06509cf
+GOLANGCI_LINT_VERSION := v1.17.1
+GOLANGCI_LINT_HASHSUM := f5fa647a12f658924d9f7d6b9628d505ab118e8e049e43272de6526053ebe08d
 
 ###
 # Functions
@@ -53,7 +53,7 @@ RUNSIM          = $(TOOLS_DESTDIR)/runsim
 all: tools
 
 tools: tools-stamp
-tools-stamp: $(STATIK) $(GOIMPORTS) $(CLOG) $(GOLANGCI_LINT) $(RUNSIM)
+tools-stamp: $(STATIK) $(GOIMPORTS) $(RUNSIM)
 	touch $@
 
 $(GOLANGCI_LINT): $(mkfile_dir)/install-golangci-lint.sh
@@ -63,14 +63,15 @@ $(STATIK):
 	$(call go_install,rakyll,statik,v0.1.5)
 
 $(GOIMPORTS):
-	go get golang.org/x/tools/cmd/goimports@v0.0.0-20190114222345-bf090417da8b
+	go get golang.org/x/tools/cmd/goimports@v0.0.0-20190628034336-212fb13d595e
 
 $(CLOG):
-	$(call go_install,alessio,clog,1)
+	go get github.com/cosmos/tools/cmd/clog/
 
 $(RUNSIM):
-	go get github.com/cosmos/cosmos-sdk/contrib/runsim@v0.28.2-0.20190626164114-c898dac6a9fc
-	go install -mod=readonly github.com/cosmos/cosmos-sdk/contrib/runsim
+	go get github.com/cosmos/tools/cmd/runsim/
+
+golangci-lint: $(GOLANGCI_LINT)
 
 tools-clean:
 	rm -f $(STATIK) $(GOIMPORTS) $(CLOG) $(GOLANGCI_LINT)


### PR DESCRIPTION
Update golangci-lint to latest version.

Remove ci-lint, no longer used.

Remove golangci-lint from tools target to prevent CI builds
from downloading automatically (and unnecessarily).
Developers can still run make golangci-lint to download
it locally for development and testing purposes.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
