### PR TITLE
Override GOPROXY's default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
+GOPROXY ?= direct
+goproxy := $(GOPROXY)
 
 export GO111MODULE = on
+export GOPROXY = $(goproxy)
 
 # process build tags
 


### PR DESCRIPTION
Go 1.13 uses http://proxy.golang.org as GOPROXY's default
value if the environment variable is unset or blank. This
patch makes gaia's buildsystem override Go env's default
and fallback to 'direct' if and only if GOPROXY is unset
in the user's environment.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
