### PR TITLE
deprecate GOPATH references on docs 

### DIFF
--- a/docs/deploy-testnet.md
+++ b/docs/deploy-testnet.md
@@ -12,7 +12,7 @@ Supporting code can be found in the [networks directory](https://github.com/cosm
 
 ## Available Docker images
 
-In case you need to use or deploy gaia as a container you could skip the `build` steps and use the official images, $TAG stands for the version you are interested in:
+In case you need to use or deploy gaia as a container you could skip the `build` steps and use the official images, \$TAG stands for the version you are interested in:
 
 - `docker run -it -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad init`
 - `docker run -it -p 26657:26657 -p 26656:26656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad start`
@@ -74,8 +74,11 @@ From the [networks/local directory](https://github.com/cosmos/gaia/tree/master/n
 Build the `gaiad` binary (linux) and the `tendermint/gaiadnode` docker image required for running the `localnet` commands. This binary will be mounted into the container and can be updated rebuilding the image, so you only need to build the image once.
 
 ```bash
+# Clone the gaia repo
+git clone https://github.com/cosmos/gaia.git
+
 # Work from the SDK repo
-cd $GOPATH/src/github.com/cosmos/gaia
+cd gaia
 
 # Build the linux binary in ./build
 make build-linux
@@ -95,12 +98,12 @@ make localnet-start
 This command creates a 4-node network using the gaiadnode image.
 The ports for each node are found in this table:
 
-| Node ID | P2P Port | RPC Port |
-| --------|-------|------|
-| `gaianode0` | `26656` | `26657` |
-| `gaianode1` | `26659` | `26660` |
-| `gaianode2` | `26661` | `26662` |
-| `gaianode3` | `26663` | `26664` |
+| Node ID     | P2P Port | RPC Port |
+| ----------- | -------- | -------- |
+| `gaianode0` | `26656`  | `26657`  |
+| `gaianode1` | `26659`  | `26660`  |
+| `gaianode2` | `26661`  | `26662`  |
+| `gaianode3` | `26663`  | `26664`  |
 
 To update the binary, just rebuild it and restart the nodes:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,17 +8,16 @@ mainnet as either a [Full Node](./join-mainnet.md) or a
 ## Install Go
 
 Install `go` by following the [official docs](https://golang.org/doc/install).
-Remember to set your `$GOPATH` and `$PATH` environment variables, for example:
+Remember to set your `$PATH` environment variable, for example:
 
 ```bash
 mkdir -p $HOME/go/bin
-echo "export GOPATH=$HOME/go" >> ~/.bash_profile
-echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.bash_profile
+echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 
 ::: tip
-**Go 1.12+** is required for the Cosmos SDK.
+**Go 1.13+** is required for the Cosmos SDK.
 :::
 
 ## Install the binaries

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ Remember to set your `$PATH` environment variable, for example:
 
 ```bash
 mkdir -p $HOME/go/bin
-echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
+echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 

--- a/docs/join-testnet.md
+++ b/docs/join-testnet.md
@@ -50,7 +50,7 @@ Now it is time to upgrade the software:
 git clone https://github.com/cosmos/gaia.git
 cd gaia
 git fetch --all && git checkout master
-make update_tools install
+make install
 ```
 
 ::: tip

--- a/docs/join-testnet.md
+++ b/docs/join-testnet.md
@@ -1,4 +1,4 @@
-# Join the Public Testnet 
+# Join the Public Testnet
 
 ::: tip Current Testnet
 See the [testnet repo](https://github.com/cosmos/testnets) for
@@ -47,13 +47,14 @@ Make sure that every node has a unique `priv_validator.json`. Do not copy the `p
 Now it is time to upgrade the software:
 
 ```bash
-cd $GOPATH/src/github.com/cosmos/gaia
+git clone https://github.com/cosmos/gaia.git
+cd gaia
 git fetch --all && git checkout master
 make update_tools install
 ```
 
 ::: tip
-*NOTE*: If you have issues at this step, please check that you have the latest stable version of GO installed.
+_NOTE_: If you have issues at this step, please check that you have the latest stable version of GO installed.
 :::
 
 Note we use `master` here since it contains the latest stable release.

--- a/docs/translations/cn/deploy-testnet.md
+++ b/docs/translations/cn/deploy-testnet.md
@@ -6,30 +6,31 @@
 2. 多节点，本地的，自动的测试网
 3. 多节点，远程的，自动的测试网
 
-支持代码可以在[networks目录](https://github.com/cosmos/cosmos-sdk/tree/develop/networks)中找到，还可以在`local`或`remote`子目录中找到。
+支持代码可以在[networks 目录](https://github.com/cosmos/cosmos-sdk/tree/develop/networks)中找到，还可以在`local`或`remote`子目录中找到。
 
 > 注意：`remote`网络引导教程可能与最新版本不同步，不可完全依赖。
 
-## 可获取的Docker镜像
+## 可获取的 Docker 镜像
 
-如果你需要使用或部署gaia作为容器，你可以跳过`build`步骤并使用官方镜像，$TAG标识你感兴趣的版本：
+如果你需要使用或部署 gaia 作为容器，你可以跳过`build`步骤并使用官方镜像，\$TAG 标识你感兴趣的版本：
 
-+ `docker run -it -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad init`
-+ `docker run -it -p 26657:26657 -p 26656:26656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad start`
-+ ...
-+ `docker run -it -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiacli version`
+- `docker run -it -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad init`
+- `docker run -it -p 26657:26657 -p 26656:26656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad start`
+- ...
+- `docker run -it -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiacli version`
 
-相同的镜像也可以用于构建你自己的docker-compose栈
+相同的镜像也可以用于构建你自己的 docker-compose 栈
 
 ## 单节点，本地的，手动的测试网
 
 本教程可帮助你创建一个在本地运行网络的验证人节点，以进行测试和其他相关的用途。
 
 ### 需要
-+ [安装gaia](./installation.md)
-+ [安装`jq`](https://stedolan.github.io/jq/download/)(可选的)
 
-### 创建genesis文件并启动网络
+- [安装 gaia](./installation.md)
+- [安装`jq`](https://stedolan.github.io/jq/download/)(可选的)
+
+### 创建 genesis 文件并启动网络
 
 ```bash
 # You can run all of these commands from your home directory
@@ -56,25 +57,28 @@ gaiad collect-gentxs
 gaiad start
 ```
 
-启动将会把`gaiad`相关的所有数据放在`~/.gaiad`目录。你可以检查所创建的genesis文件——`~/.gaiad/config/genesis.json`。同时`gaiacli`也已经配置完成并且有了一个拥有token的账户(stake和自定义的代币)。
+启动将会把`gaiad`相关的所有数据放在`~/.gaiad`目录。你可以检查所创建的 genesis 文件——`~/.gaiad/config/genesis.json`。同时`gaiacli`也已经配置完成并且有了一个拥有 token 的账户(stake 和自定义的代币)。
 
 ## 多节点，本地的，自动的测试网
 
-在[networks/local目录](https://github.com/cosmos/cosmos-sdk/tree/develop/networks/local)中运行如下命令:
+在[networks/local 目录](https://github.com/cosmos/cosmos-sdk/tree/develop/networks/local)中运行如下命令:
 
 ### 需要
-+ [安装gaia](./installation.md)
-+ [安装docker](https://docs.docker.com/install/)
-+ [安装docker-compose](https://docs.docker.com/compose/install/)
 
+- [安装 gaia](./installation.md)
+- [安装 docker](https://docs.docker.com/install/)
+- [安装 docker-compose](https://docs.docker.com/compose/install/)
 
 ### 编译
 
-编译`gaiad`二进制文件(linux)和运行`localnet`命令所需的`tendermint/gaianode` docker images。这个二进制文件将被安装到container中，并且可以更新重建image，因此您只需要构建一次image。
+编译`gaiad`二进制文件(linux)和运行`localnet`命令所需的`tendermint/gaianode` docker images。这个二进制文件将被安装到 container 中，并且可以更新重建 image，因此您只需要构建一次 image。
 
-```
+```bash
+# Clone the gaia repo
+git clone https://github.com/cosmos/gaia.git
+
 # Work from the SDK repo
-cd $GOPATH/src/github.com/cosmos/cosmos-sdk
+cd cosmos-sdk
 
 # Build the linux binary in ./build
 make build-linux
@@ -85,20 +89,20 @@ make build-docker-gaiadnode
 
 ### 运行你的测试网
 
-运行一个拥有4个节点的测试网络:
+运行一个拥有 4 个节点的测试网络:
 
 ```bash
 make localnet-start
 ```
 
-此命令使用gaiadnode image创建了一个4节点网络。每个节点的端口可以在下表中找到：
+此命令使用 gaiadnode image 创建了一个 4 节点网络。每个节点的端口可以在下表中找到：
 
-| `Node ID` | `P2P Port` | `RPC Port` |
-| ----- | ----- | ---- |
-| `gaianode0` | `26656` | `26657` |
-| `gaianode1` | `26659` | `26660` |
-| `gaianode2` | `26661` | `26662` |
-| `gaianode3` | `26663` | `26664` |
+| `Node ID`   | `P2P Port` | `RPC Port` |
+| ----------- | ---------- | ---------- |
+| `gaianode0` | `26656`    | `26657`    |
+| `gaianode1` | `26659`    | `26660`    |
+| `gaianode2` | `26661`    | `26662`    |
+| `gaianode3` | `26663`    | `26664`    |
 
 更新可执行程序，只需要重新编译并重启节点:
 
@@ -108,7 +112,7 @@ make build-linux localnet-start
 
 ### 配置
 
-`make localnet-start`命令通过调用`gaiad testnet`命令在`./build`中创建了一个4节点测试网络的文件。输出`./build`目录下一些文件:
+`make localnet-start`命令通过调用`gaiad testnet`命令在`./build`中创建了一个 4 节点测试网络的文件。输出`./build`目录下一些文件:
 
 ```bash
 $ tree -L 2 build/
@@ -151,16 +155,15 @@ build/
         └── data
 ```
 
-每个`./build/nodeN`目录被挂载到对应container的`/gaiad`目录。
+每个`./build/nodeN`目录被挂载到对应 container 的`/gaiad`目录。
 
 ### 日志输出
 
-日志被保存在每个`./build/nodeN/gaiad/gaia.log`文件中。你也可以直接通过Docker来查看日志：
+日志被保存在每个`./build/nodeN/gaiad/gaia.log`文件中。你也可以直接通过 Docker 来查看日志：
 
 ```bash
 docker logs -f gaiadnode0
 ```
-
 
 ### 密钥&账户
 
@@ -177,27 +180,27 @@ gaiacli keys list --home ./build/node0/gaiacli
 :::
 
 ### 特殊的可执行程序
-如果你拥有多个不同名称的可执行程序，则可以使用BINARY环境变量指定要运行的可执行程序。可执行程序的路径是相对于挂载的卷。例如：
+
+如果你拥有多个不同名称的可执行程序，则可以使用 BINARY 环境变量指定要运行的可执行程序。可执行程序的路径是相对于挂载的卷。例如：
 
 ```
 # Run with custom binary
 BINARY=gaiafoo make localnet-start
 ```
 
-
 ## 多节点，远程的，自动的测试网
 
-应该从[networks目录](https://github.com/cosmos/cosmos-sdk/tree/develop/networks)运行下面的命令。
+应该从[networks 目录](https://github.com/cosmos/cosmos-sdk/tree/develop/networks)运行下面的命令。
 
 ### Terraform & Ansible
 
-使用[Terraform](https://www.terraform.io/)在AWS上创建服务器然后用[Ansible](https://www.ansible.com/)创建并管理这些服务器上的测试网来完成自动部署。
+使用[Terraform](https://www.terraform.io/)在 AWS 上创建服务器然后用[Ansible](https://www.ansible.com/)创建并管理这些服务器上的测试网来完成自动部署。
 
 ### 前提
 
-+ 在一台Linux机器上安装[Terraform](https://www.terraform.io/downloads.html)和[Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
-+ 创建一个具有EC2实例创建能力的[ASW API token](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
-+ 创建SSH密钥
+- 在一台 Linux 机器上安装[Terraform](https://www.terraform.io/downloads.html)和[Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+- 创建一个具有 EC2 实例创建能力的[ASW API token](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
+- 创建 SSH 密钥
 
 ```
 export AWS_ACCESS_KEY_ID="2345234jk2lh4234"
@@ -216,12 +219,11 @@ export SSH_PUBLIC_FILE="$HOME/.ssh/id_rsa.pub"
 SERVERS=1 REGION_LIMIT=1 make validators-start
 ```
 
-测试网络的名称将由`--chain-id`定义，集群的名称则是AWS中服务器管理标识。该代码将在每个可用区中创建服务器数量的服务器，最多为REGION_LIMIT，从us-east-2开始。（us-east-1被排除在外）下面的BaSH脚本也是如此，但更便于输入。
+测试网络的名称将由`--chain-id`定义，集群的名称则是 AWS 中服务器管理标识。该代码将在每个可用区中创建服务器数量的服务器，最多为 REGION_LIMIT，从 us-east-2 开始。（us-east-1 被排除在外）下面的 BaSH 脚本也是如此，但更便于输入。
 
 ```
 ./new-testnet.sh "$TESTNET_NAME" "$CLUSTER_NAME" 1 1
 ```
-
 
 ### 快速查询状态入口
 
@@ -229,16 +231,15 @@ SERVERS=1 REGION_LIMIT=1 make validators-start
 make validators-status
 ```
 
-
 ### 删除服务器
 
 ```
 make validators-stop
 ```
 
-
 ### 日志输出
-你可以将日志发送到Logz.io，一个Elastic栈（Elastic搜索，Logstash和Kibana）服务提供商。你可以将节点设置为自动登录。创建一个帐户并从此页面上的说明中获取你的API密钥，然后：
+
+你可以将日志发送到 Logz.io，一个 Elastic 栈（Elastic 搜索，Logstash 和 Kibana）服务提供商。你可以将节点设置为自动登录。创建一个帐户并从此页面上的说明中获取你的 API 密钥，然后：
 
 ```
 yum install systemd-devel || echo "This will only work on RHEL-based systems."
@@ -248,10 +249,9 @@ go get github.com/mheese/journalbeat
 ansible-playbook -i inventory/digital_ocean.py -l remotenet logzio.yml -e LOGZIO_TOKEN=ABCDEFGHIJKLMNOPQRSTUVWXYZ012345
 ```
 
-
 ### 监控
 
-你可以安装DataDog代理：
+你可以安装 DataDog 代理：
 
 ```
 make datadog-install

--- a/docs/translations/cn/installation.md
+++ b/docs/translations/cn/installation.md
@@ -4,12 +4,11 @@
 
 ### 安装 Go
 
-按照[官方文档](https://golang.org/doc/install)安装`go`。记得设置环境变量 `$GOBIN`和`$PATH`:
+按照[官方文档](https://golang.org/doc/install)安装`go`。记得设置环境变量 `$PATH`:
 
 ```bash
 mkdir -p $HOME/go/bin
-echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
-echo "export GO111MODULE=on" >> ~/.bash_profile
+echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 

--- a/docs/translations/cn/installation.md
+++ b/docs/translations/cn/installation.md
@@ -1,26 +1,25 @@
-## 安装Gaia
+## 安装 Gaia
 
 本教程将详细说明如何在你的系统上安装`gaiad`和`gaiacli`。安装后，你可以作为[全节点](./join-mainnet.md)或是[验证人节点](./validators/validator-setup.md)加入到主网。
 
-### 安装Go
+### 安装 Go
 
-按照[官方文档](https://golang.org/doc/install)安装`go`。记得设置环境变量`$GOPATH`,`$GOBIN`和`$PATH`:
+按照[官方文档](https://golang.org/doc/install)安装`go`。记得设置环境变量 `$GOBIN`和`$PATH`:
 
 ```bash
 mkdir -p $HOME/go/bin
-echo "export GOPATH=$HOME/go" >> ~/.bash_profile
-echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.bash_profile
+echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
 echo "export GO111MODULE=on" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 
 ::: tip
-Cosmos SDK需要安装**Go 1.12+**
+Cosmos SDK 需要安装**Go 1.12+**
 :::
 
 ### 安装二进制执行程序
 
-接下来，安装最新版本的Gaia。需要确认您 `git checkout 了正确的[发布版本](https://github.com/cosmos/cosmos-sdk/releases)。
+接下来，安装最新版本的 Gaia。需要确认您 `git checkout 了正确的[发布版本](https://github.com/cosmos/cosmos-sdk/releases)。
 
 ::: warning
 对于主网，请确保你的版本大于或等于`v0.33.0`
@@ -31,7 +30,7 @@ git clone -b <latest-release-tag> https://github.com/cosmos/gaia
 cd gaia && make install
 ```
 
-> *注意*: 如果在这一步中出现问题，请检查你是否安装的是Go的最新稳定版本。
+> _注意_: 如果在这一步中出现问题，请检查你是否安装的是 Go 的最新稳定版本。
 
 等`gaiad`和`gaiacli`可执行程序安装完之后，请检查:
 
@@ -52,12 +51,13 @@ go version go1.12 linux/amd64
 
 ##### Build Tags
 
-build tags指定了可执行程序具有的特殊特性。
+build tags 指定了可执行程序具有的特殊特性。
 
-| Build Tag | Description                                     |
-| --------- | ----------------------------------------------- |
-| netgo     | Name resolution will use pure Go code           |
-| ledger    | 支持Ledger设备(硬件钱包) |
+| Build Tag | Description                           |
+| --------- | ------------------------------------- |
+| netgo     | Name resolution will use pure Go code |
+| ledger    | 支持 Ledger 设备(硬件钱包)            |
 
 ### 接下来
+
 然后你可以选择 加入[主网](./join-mainnet.md)、[公共测试网](./join-testnet.md) 或是 [创建私有测试网](./deploy-testnet.md)。

--- a/docs/translations/cn/join-testnet.md
+++ b/docs/translations/cn/join-testnet.md
@@ -1,7 +1,7 @@
 # 加入公共测试网
 
 ::: 提示 当前测试网
-请查看[testnet repo](https://github.com/cosmos/testnets)获取最新的公共测试网信息，包含了所使用的Cosmos-SDK的正确版本和genesis文件。
+请查看[testnet repo](https://github.com/cosmos/testnets)获取最新的公共测试网信息，包含了所使用的 Cosmos-SDK 的正确版本和 genesis 文件。
 :::
 
 ::: 警告
@@ -10,18 +10,17 @@
 
 ## 创建一个新节点
 
-> 注意：如果你在之前的测试网中运行过一个全节点，请跳至[升级之前的Testnet](#upgrading-from-previous-testnet)。
+> 注意：如果你在之前的测试网中运行过一个全节点，请跳至[升级之前的 Testnet](#upgrading-from-previous-testnet)。
 
 要创建一个新节点，主网的指令同样适用：
 
-+ [加入mainnet](./join-mainnet.md)
-+ [部署验证人节点](./validators/validator-setup.md)
+- [加入 mainnet](./join-mainnet.md)
+- [部署验证人节点](./validators/validator-setup.md)
 
-只有SDK的版本和genesis文件不同。查看[testnet repo](https://github.com/cosmos/testnets)
-获取测试网的信息，包括Cosmos-SDK正确的版本和genesis文件。
+只有 SDK 的版本和 genesis 文件不同。查看[testnet repo](https://github.com/cosmos/testnets)
+获取测试网的信息，包括 Cosmos-SDK 正确的版本和 genesis 文件。
 
-
-## 升级之前的Testnet
+## 升级之前的 Testnet
 
 这些指令用以把运行过以前测试网络的全节点升级至最新的测试网络。
 
@@ -45,15 +44,16 @@ gaiad unsafe-reset-all
 现在升级软件：
 
 ```bash
-cd $GOPATH/src/github.com/cosmos/cosmos-sdk
+git clone https://github.com/cosmos/cosmos-sdk.git
+cd cosmos-sdk
 git fetch --all && git checkout master
 make update_tools install
 ```
 
 ::: 提示
-*注意*：如果在这一步出现问题，请检查是否安装了最新稳定版本的Go。
+_注意_：如果在这一步出现问题，请检查是否安装了最新稳定版本的 Go。
 :::
 
-注意这里我们使用的是包含最新稳定发布版本的`master`分支。请查看[testnet repo](https://github.com/cosmos/testnets)查看哪个版本的测试网需要哪一个Cosmos-SDK版本，在[SDK发布版](https://github.com/cosmos/cosmos-sdk/releases)中对应的详细信息。
+注意这里我们使用的是包含最新稳定发布版本的`master`分支。请查看[testnet repo](https://github.com/cosmos/testnets)查看哪个版本的测试网需要哪一个 Cosmos-SDK 版本，在[SDK 发布版](https://github.com/cosmos/cosmos-sdk/releases)中对应的详细信息。
 
 你的全节点已经升级成功！

--- a/docs/translations/cn/join-testnet.md
+++ b/docs/translations/cn/join-testnet.md
@@ -47,7 +47,7 @@ gaiad unsafe-reset-all
 git clone https://github.com/cosmos/cosmos-sdk.git
 cd cosmos-sdk
 git fetch --all && git checkout master
-make update_tools install
+make install
 ```
 
 ::: 提示

--- a/docs/translations/kr/deploy-testnet.md
+++ b/docs/translations/kr/deploy-testnet.md
@@ -12,7 +12,7 @@
 
 ## Docker 이미지
 
-컨테이너 형태로 Gaia 디플로이를 원하시는 경우, `build` 단계를 건너뛰시고 공식 이미지 파일을 설치하실 수 있습니다. $TAG은 설치하시려는 버전을 의미합니다.
+컨테이너 형태로 Gaia 디플로이를 원하시는 경우, `build` 단계를 건너뛰시고 공식 이미지 파일을 설치하실 수 있습니다. \$TAG은 설치하시려는 버전을 의미합니다.
 
 - `docker run -it -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad init`
 - `docker run -it -p 26657:26657 -p 26656:26656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli tendermint:$TAG gaiad start`
@@ -55,7 +55,7 @@ gaiad collect-gentxs
 gaiad start
 ```
 
-이 셋업은 모든 `gaiad` 정보를  `~/.gaiad`에 저장힙니다. 생성하신 제네시스 파일을 확인하고 싶으시다면 `~/.gaiad/config/genesis.json`에서 확인이 가능합니다. 위의 세팅으로 `gaiacli`가 이용이 가능하며, 토큰(스테이킹/커스텀)이 있는 계정 또한 함께 생성됩니다.
+이 셋업은 모든 `gaiad` 정보를 `~/.gaiad`에 저장힙니다. 생성하신 제네시스 파일을 확인하고 싶으시다면 `~/.gaiad/config/genesis.json`에서 확인이 가능합니다. 위의 세팅으로 `gaiacli`가 이용이 가능하며, 토큰(스테이킹/커스텀)이 있는 계정 또한 함께 생성됩니다.
 
 ## 멀티 노드, 로컬, 자동 테스트넷
 
@@ -72,8 +72,11 @@ gaiad start
 `localnet` 커맨드를 운영하기 위한 `gaiad` 바이너리(리눅스)와 `tendermint/gaiadnode` docker 이미지를 생성합니다. 해당 바이너리는 컨테이너에 마운팅 되며 업데이트를 통해 이미지를 리빌드 하실 수 있습니다.
 
 ```bash
+# Clone the gaia repo
+git clone https://github.com/cosmos/gaia.git
+
 # Work from the SDK repo
-cd $GOPATH/src/github.com/cosmos/gaia
+cd gaia
 
 # Build the linux binary in ./build
 make build-linux
@@ -92,13 +95,12 @@ make localnet-start
 
 이 커맨드는 4개 노드로 구성되어있는 네트워크를 gaiadnode 이미지를 기반으로 생성합니다. 각 노드의 포트는 하단 테이블에서 확인하실 수 있습니다:
 
-
-| 노드 ID | P2P 포트 | RPC 포트 |
-| --------|-------|------|
-| `gaianode0` | `26656` | `26657` |
-| `gaianode1` | `26659` | `26660` |
-| `gaianode2` | `26661` | `26662` |
-| `gaianode3` | `26663` | `26664` |
+| 노드 ID     | P2P 포트 | RPC 포트 |
+| ----------- | -------- | -------- |
+| `gaianode0` | `26656`  | `26657`  |
+| `gaianode1` | `26659`  | `26660`  |
+| `gaianode2` | `26661`  | `26662`  |
+| `gaianode3` | `26663`  | `26664`  |
 
 바이너리를 업데이트 하기 위해서는 리빌드를 하신 후 노드를 재시작 하시면 됩니다:
 
@@ -109,7 +111,6 @@ make build-linux localnet-start
 ### 설정
 
 `make localnet-start`는 `gaiad testnet` 명령을 호출하여 4개 노드로 구성된 테스트넷에 필요한 파일을 `./build`에 저장합니다. 이 명령은 `./build` 디렉토리에 다수의 파일을 내보냅니다.
-
 
 ```bash
 $ tree -L 2 build/
@@ -164,12 +165,12 @@ docker logs -f gaiadnode0
 
 ### 키와 계정
 
-`gaiacli`를 이용해 tx를 생성하거나 상태를 쿼리 하시려면, 특정 노드의 `gaiacli` 디렉토리를 `home`처럼 이용하시면 됩니다. 예를들어: 
-
+`gaiacli`를 이용해 tx를 생성하거나 상태를 쿼리 하시려면, 특정 노드의 `gaiacli` 디렉토리를 `home`처럼 이용하시면 됩니다. 예를들어:
 
 ```shell
 gaiacli keys list --home ./build/node0/gaiacli
 ```
+
 이제 계정이 존재하니 추가로 새로운 계정을 만들고 계정들에게 토큰을 전송할 수 있습니다.
 
 ::: tip
@@ -179,6 +180,7 @@ gaiacli keys list --home ./build/node0/gaiacli
 ### 특수 바이너리
 
 다수의 이름을 가진 다수의 바이너리를 소유하신 경우, 어떤 바이너리의 환경 변수(environment variable)를 기준으로 실행할지 선택할 수 있습니다. 바이너리의 패스(path)는 관련 볼륨(volume)에 따라 달라집니다. 예시:
+
 ```
 # Run with custom binary
 BINARY=gaiafoo make localnet-start

--- a/docs/translations/kr/installation.md
+++ b/docs/translations/kr/installation.md
@@ -8,7 +8,7 @@
 
 ```bash
 mkdir -p $HOME/go/bin
-echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
+echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 

--- a/docs/translations/kr/installation.md
+++ b/docs/translations/kr/installation.md
@@ -4,12 +4,11 @@
 
 ### Go 설치하기
 
-공식 [Go 문서](https://golang.org/doc/install)를 따라서 `go`를 설치하십시오. `$GOPATH`, 그리고 `$PATH`의 환경을 꼭 세팅하세요. 예시: 
+공식 [Go 문서](https://golang.org/doc/install)를 따라서 `go`를 설치하십시오. 그리고 `$PATH`의 환경을 꼭 세팅하세요. 예시:
 
 ```bash
 mkdir -p $HOME/go/bin
-echo "export GOPATH=$HOME/go" >> ~/.bash_profile
-echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.bash_profile
+echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 
@@ -42,10 +41,9 @@ make: *** [install] Error 2
 LDFLAGS="" make install
 ```
 
-> *참고*: 여기에서 문제가 발생한다면, Go의 최신 스테이블 버전이 설치되어있는지 확인하십시오.
+> _참고_: 여기에서 문제가 발생한다면, Go의 최신 스테이블 버전이 설치되어있는지 확인하십시오.
 
 위 절차를 따라하시면 `gaiad`와 `gaiacli` 바이너리가 설치될 것입니다. 설치가 잘 되어있는지 확인하십시오:
-
 
 ```bash
 $ gaiad version --long
@@ -68,10 +66,10 @@ go: go version go1.12.5 darwin/amd64
 
 빌드 태그는 해당 바이너리에서 활성화된 특별 기능을 표기합니다.
 
-| 빌드 태그   | 설명                                             |
-| --------- | ----------------------------------------------- |
-| netgo     | Name resolution이 오직 Go 코드만을 사용합니다          |
-| ledger    | 렛저 기기(하드웨어 지갑)이 지원됩니다                    |
+| 빌드 태그 | 설명                                          |
+| --------- | --------------------------------------------- |
+| netgo     | Name resolution이 오직 Go 코드만을 사용합니다 |
+| ledger    | 렛저 기기(하드웨어 지갑)이 지원됩니다         |
 
 ### snap을 사용해 바이너리 설치하기 (리눅스에만 해당)
 

--- a/docs/translations/kr/join-testnet.md
+++ b/docs/translations/kr/join-testnet.md
@@ -72,7 +72,7 @@ gaiad unsafe-reset-all
 git clone https://github.com/cosmos/cosmos-sdk.git
 cd cosmos-sdk
 git fetch --all && git checkout master
-make update_tools install
+make install
 ```
 
 ::: tip

--- a/docs/translations/kr/join-testnet.md
+++ b/docs/translations/kr/join-testnet.md
@@ -43,7 +43,6 @@ moniker = "<your_custom_moniker>"
 minimum_fees = ""
 ```
 
-
 당신의 풀노드가 활성화 되었습니다! [제네시스와 시드](#genesis-seeds)로 넘어가주세요.
 
 ## 과거 테스트넷에서 업그레이드 하기
@@ -70,13 +69,14 @@ gaiad unsafe-reset-all
 이제 소프트웨어를 업그레이드할 시간입니다:
 
 ```bash
-cd $GOPATH/src/github.com/cosmos/cosmos-sdk
+git clone https://github.com/cosmos/cosmos-sdk.git
+cd cosmos-sdk
 git fetch --all && git checkout master
 make update_tools install
 ```
 
 ::: tip
-*참고*: 이 단계에서 문제가 있으시다면 최신 스테이블 GO 버전이 설치되어있는지 확인해주세요.
+_참고_: 이 단계에서 문제가 있으시다면 최신 스테이블 GO 버전이 설치되어있는지 확인해주세요.
 :::
 
 위 예시에서는 가장 최신 스테이블 릴리즈가 있는 `master`를 사용합니다. 테스트넷마다 운용하는 릴리즈가 다를 경우가 있으니 [testnet repo](https://github.com/cosmos/testnets)를 확인하셔서 어떤 버전이 필요한지 확인하시고, [SDK 릴리즈 페이지](https://github.com/cosmos/cosmos-sdk/releases)에서 각 릴리즈에 대한 정보를 확인하세요.
@@ -106,7 +106,7 @@ gaiad start
 
 이제 노드가 다른 피어들을 찾는 방법을 알아야합니다. `$HOME/.gaiad/config/config.toml`에 안정적인 시드 노드들을 추가할 차례입니다. `testnets` repo에 각 테스트넷에 대한 시드 노드 링크가 포함되어있습니다. 만약 현재 운영되고 있는 테스트넷을 참가하고 싶으시다면 [여기](https://github.com/cosmos/testnets)에서 어떤 노드를 이용할지 확인하세요.
 
-만약 해당 시드가 작동하지 않는다면, 추가적인 시드와 피어들을 [코스모스 익스플로러](https://explorer.cosmos.network/nodes)를 통해 확인하실 수 있습니다. `Full Nodes` 탭을 들어가셔서 프라이빗(`10.x.x.x`) 또는 로컬 IP 주소(https://en.wikipedia.org/wiki/Private_network)가 *아닌* 노드를 열어보세요. `Persistent Peer` 값에 연결 스트링(connection string)이 표기되어 있습니다. 가장 최적화된 결과를 위해서는 4-6을 이용하세요.
+만약 해당 시드가 작동하지 않는다면, 추가적인 시드와 피어들을 [코스모스 익스플로러](https://explorer.cosmos.network/nodes)를 통해 확인하실 수 있습니다. `Full Nodes` 탭을 들어가셔서 프라이빗(`10.x.x.x`) 또는 로컬 IP 주소(https://en.wikipedia.org/wiki/Private_network)가 _아닌_ 노드를 열어보세요. `Persistent Peer` 값에 연결 스트링(connection string)이 표기되어 있습니다. 가장 최적화된 결과를 위해서는 4-6을 이용하세요.
 
 이 외에도 [밸리데이터 라이엇 채팅방](https://riot.im/app/#/room/#cosmos-validators:matrix.org)을 통해서 피어 요청을 할 수 있습니다.
 

--- a/docs/translations/kr/upgrade-node.md
+++ b/docs/translations/kr/upgrade-node.md
@@ -7,13 +7,13 @@
 우선 `gaiad` 인스턴스를 중지하세요. 이후 소프트웨어를 업그레이드하세요:
 
 ```bash
-cd $GOPATH/src/github.com/cosmos/gaia
+cd gaia
 git fetch --all && git checkout <new_version>
 make install
 ```
 
 ::: tip
-*참고*: 이번 단계에서 문제가 발생하는 경우, 최신 스테이블 버전의 Go가 설치되어있는지 확인하세요.
+_참고_: 이번 단계에서 문제가 발생하는 경우, 최신 스테이블 버전의 Go가 설치되어있는지 확인하세요.
 :::
 
 최신 퍼블릭 테스트넷에 필요한 버전 정보를 확인하기 위해서는 [테스트넷 리포](https://github.com/cosmos/testnets)를 참고하시고, 각 릴리즈에 대한 자세한 정보는 [Gaia 릴리즈 페이지](https://github.com/cosmos/Gaia/releases)를 참고하세요.
@@ -61,14 +61,13 @@ mv new_genesis.json genesis.json
 
 이 상태에서 내보낸 제네시스 파일을 새로운 버전과 호환되는 제네시스 파일로 변환하는 스크립트를 실행하셔야될 수 있습니다. 예를 들어, `Account` 타입의 형태가 바뀐경우, 스크립트는 account store에서 인코딩된 계정을 확인하고, 언마셜하고, 타입을 업데이트한 후 다시 마셜링을 진행한 다음에 복구하는 작업을 진행합니다. 스크립트의 예시는 [여기](https://github.com/cosmos/cosmos-sdk/blob/master/contrib/export/v0.33.x-to-v0.34.0.py).를 참고하세요
 
-
 ## 데이터 리셋하기
 
-:::warning 
-만약 업그레이드하는 <새로운_버전(new_version)>에 'breaking change'가 포함되는 않은 경우, 데이터를 리셋할 필요가 없습니다. 만약 'breaking change'가 포함되지 않은 경우, 바로 [Restart](#restart) 항목으로 넘어가세요.
+:::warning
+만약 업그레이드하는 <새로운\_버전(new_version)>에 'breaking change'가 포함되는 않은 경우, 데이터를 리셋할 필요가 없습니다. 만약 'breaking change'가 포함되지 않은 경우, 바로 [Restart](#restart) 항목으로 넘어가세요.
 :::
 
-::: warning 
+::: warning
 메인넷에서 **검증인 노드**를 운영하시는 경우, `gaiad unsafe-reset-all` 명령어를 실행하실때 주의를 기울이세요. `chain-id`를 변경하지 않는 이상 이 명령어를 실행할 필요가 없습니다.
 :::
 

--- a/docs/upgrade-node.md
+++ b/docs/upgrade-node.md
@@ -1,36 +1,36 @@
 # Upgrade Your Node
 
-This document describes the upgrade procedure of a `gaiad` full-node to a new version. 
+This document describes the upgrade procedure of a `gaiad` full-node to a new version.
 
 ## Software Upgrade
 
 First, stop your instance of `gaiad`. Next, upgrade the software:
 
 ```bash
-cd $GOPATH/src/github.com/cosmos/gaia
+cd gaia
 git fetch --all && git checkout <new_version>
 make install
 ```
 
 ::: tip
-*NOTE*: If you have issues at this step, please check that you have the latest stable version of GO installed.
+_NOTE_: If you have issues at this step, please check that you have the latest stable version of GO installed.
 :::
 
 See the [testnet repo](https://github.com/cosmos/testnets) for details on which version is needed for which public testnet, and the [Gaia release page](https://github.com/cosmos/Gaia/releases) for details on each release.
 
 Your full node has been cleanly upgraded!
 
-## Upgrade Genesis File 
+## Upgrade Genesis File
 
-:::warning 
+:::warning
 If the new version you are upgrading to has breaking changes, you will have to restart your chain. If it is not breaking, you can skip to [Restart](#restart)
 :::
 
-To upgrade the genesis file, you can either fetch it from a trusted source or export it locally. 
+To upgrade the genesis file, you can either fetch it from a trusted source or export it locally.
 
 ### Fetching from a Trusted Source
 
-If you are joining the mainnet, fetch the genesis from the [mainnet repo](https://github.com/cosmos/launch). If you are joining a public testnet, fetch the genesis from the appropriate testnet in the [testnet repo](https://github.com/cosmos/testnets). Otherwise, fetch it from your trusted source. 
+If you are joining the mainnet, fetch the genesis from the [mainnet repo](https://github.com/cosmos/launch). If you are joining a public testnet, fetch the genesis from the appropriate testnet in the [testnet repo](https://github.com/cosmos/testnets). Otherwise, fetch it from your trusted source.
 
 Save the new genesis as `new_genesis.json`. Then replace the old `genesis.json` with `new_genesis.json`
 
@@ -40,18 +40,18 @@ cp -f genesis.json new_genesis.json
 mv new_genesis.json genesis.json
 ```
 
-Then, go to the [reset data](#reset-data) section. 
+Then, go to the [reset data](#reset-data) section.
 
 ### Exporting State to a New Genesis Locally
 
-If you were running a node in the previous version of the network and want to build your new genesis locally from a state of this previous network, use the following command: 
+If you were running a node in the previous version of the network and want to build your new genesis locally from a state of this previous network, use the following command:
 
 ```bash
 cd $HOME/.gaiad/config
 gaiad export --for-zero-height --height=<export-height> > new_genesis.json
 ```
 
-The command above take a state at a certain height `<export-height>` and turns it into a new genesis file that can be used to start a new network. 
+The command above take a state at a certain height `<export-height>` and turns it into a new genesis file that can be used to start a new network.
 
 Then, replace the old `genesis.json` with `new_genesis.json`.
 
@@ -64,11 +64,11 @@ At this point, you might want to run a script to update the exported genesis int
 
 ## Reset Data
 
-:::warning 
+:::warning
 If the version <new_version> you are upgrading to is not breaking from the previous one, you should not reset the data. If it is not breaking, you can skip to [Restart](#restart)
 :::
 
-::: warning 
+::: warning
 If you are running a **validator node** on the mainnet, always be careful when doing `gaiad unsafe-reset-all`. You should never use this command if you are not switching `chain-id`.
 :::
 
@@ -76,7 +76,7 @@ If you are running a **validator node** on the mainnet, always be careful when d
 Make sure that every node has a unique `priv_validator.json`. Do not copy the `priv_validator.json` from an old node to multiple new nodes. Running two nodes with the same `priv_validator.json` will cause you to get slashed due to double sign !
 :::
 
-First, remove the outdated files and reset the data. **If you are running a validator node, make sure you understand what you are doing before resetting**. 
+First, remove the outdated files and reset the data. **If you are running a validator node, make sure you understand what you are doing before resetting**.
 
 ```bash
 gaiad unsafe-reset-all


### PR DESCRIPTION
- deprecate setting of gopath in docs and bump min version to go1.13


sorry for the formatting of the files, if you want I can undo the changes, just let me know
Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
