### PR TITLE
speed up reproducible builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,17 +313,11 @@ jobs:
           no_output_timeout: 20m
           command: |
             sudo apt-get install -y ruby
-            bash -x ./contrib/gitian-build.sh all
-            for os in darwin linux windows; do
-              cp gitian-build-${os}/result/gaia-${os}-res.yml .
-              rm -rf gitian-build-${os}/
-            done
+            bash -x ./contrib/gitian-build.sh multi
+            cp gitian-build-multi/result/gaia-multi-res.yml .
+            rm -rf gitian-build-multi/
       - store_artifacts:
-          path: /go/src/github.com/cosmos/gaia/gaia-darwin-res.yml
-      - store_artifacts:
-          path: /go/src/github.com/cosmos/gaia/gaia-linux-res.yml
-      - store_artifacts:
-          path: /go/src/github.com/cosmos/gaia/gaia-windows-res.yml
+          path: /go/src/github.com/cosmos/gaia/gaia-multi-res.yml
 
 # FIXME: The `setup-contract-tests-data` make target is broken as it completely
 # overrides the .gaiad directory.

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 GITIAN_CACHE_DIRNAME='.gitian-builder-cache'
-GO_RELEASE='1.13.3'
+GO_RELEASE='1.13.7'
 GO_TARBALL="go${GO_RELEASE}.linux-amd64.tar.gz"
 GO_TARBALL_URL="https://dl.google.com/go/${GO_TARBALL}"
 
@@ -145,7 +145,7 @@ f_demangle_platforms() {
   case "${1}" in
   all)
     printf '%s' 'darwin linux windows' ;;
-  linux|darwin|windows)
+  linux|darwin|windows|multi)
     printf '%s' "${1}" ;;
   *)
     echo "invalid platform -- ${1}"

--- a/contrib/gitian-descriptors/gitian-darwin.yml
+++ b/contrib/gitian-descriptors/gitian-darwin.yml
@@ -23,11 +23,11 @@ remotes:
 - "url": "https://github.com/cosmos/gaia.git"
   "dir": "gaia"
 files:
-- "go1.13.3.linux-amd64.tar.gz"
+- "go1.13.7.linux-amd64.tar.gz"
 script: |
   set -e -o pipefail
 
-  GO_SRC_RELEASE=go1.13.3.linux-amd64
+  GO_SRC_RELEASE=go1.13.7.linux-amd64
   GO_SRC_TARBALL="${GO_SRC_RELEASE}.tar.gz"
   # Compile go and configure the environment
   export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""

--- a/contrib/gitian-descriptors/gitian-multi.yml
+++ b/contrib/gitian-descriptors/gitian-multi.yml
@@ -1,5 +1,5 @@
 ---
-name: "gaia-linux"
+name: "gaia-multi"
 enable_cache: true
 distro: "ubuntu"
 suites:
@@ -43,7 +43,11 @@ script: |
   export PATH_orig=${PATH}
   export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-  export ARCHS='386 amd64 arm arm64'
+  declare -A OS_ARCHS
+  OS_ARCHS[linux]='386 amd64 arm arm64'
+  OS_ARCHS[darwin]='386 amd64'
+  OS_ARCHS[windows]='386 amd64'
+
   export GO111MODULE=on
 
   # Make release tarball
@@ -72,7 +76,7 @@ script: |
   popd
 
   # Configure LDFLAGS for reproducible builds
-  LDFLAGS="-extldflags=-static -buildid=${VERSION} -s -w \
+  LDFLAGS="-buildid=${VERSION} -s -w \
     -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
     -X github.com/cosmos/cosmos-sdk/version.ServerName=gaiad \
     -X github.com/cosmos/cosmos-sdk/version.ClientName=gaiacli \
@@ -80,31 +84,36 @@ script: |
     -X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
     -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger"
 
+  # Build
+
   # Extract release tarball and build
-  for arch in ${ARCHS}; do
-    INSTALLPATH=`pwd`/installed/${DISTNAME}-${arch}
-    mkdir -p ${INSTALLPATH}
+  for os in "${!OS_ARCHS[@]}"; do
+    exe_file_extension=''
+    if [ ${os} = windows ]; then
+      exe_file_extension='.exe'
+    fi
 
-    # Build gaia tool suite
-    pushd ${distsrc}
-    for prog in gaiacli gaiad; do
-      GOARCH=${arch} GOROOT_FINAL=${GOROOT} go build -a \
-        -trimpath \
-        -gcflags=all=-trimpath=${GOPATH} \
-        -asmflags=all=-trimpath=${GOPATH} \
-        -mod=readonly -tags "netgo ledger" \
-        -ldflags="${LDFLAGS}" \
-        -o ${INSTALLPATH}/${prog} ./cmd/${prog}
+    for arch in ${OS_ARCHS[$os]} ; do
+      INSTALLPATH=`pwd`/installed/
+      mkdir -p ${INSTALLPATH}
 
+      # Build gaia tool suite
+      pushd ${distsrc}
+      for prog in gaiacli gaiad; do
+        GOOS=${os} GOARCH=${arch} GOROOT_FINAL=${GOROOT} go build -a \
+          -trimpath \
+          -mod=readonly -tags "netgo ledger" \
+          -ldflags="${LDFLAGS}" \
+          -o ${INSTALLPATH}/${DISTNAME}-${os}-${arch}-${prog}${exe_file_extension} ./cmd/${prog}
+
+      done
+      popd # ${distsrc}
+
+      cp ${INSTALLPATH}/* ${OUTDIR}/
     done
-    popd # ${distsrc}
 
-    pushd ${INSTALLPATH}
-    find -type f | sort | tar \
-      --no-recursion --mode='u+rw,go+r-w,a+X' \
-      --numeric-owner --sort=name \
-      --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-linux-${arch}.tar.gz
-    popd  # installed
+    unset exe_file_extension
+
   done
 
   rm -rf ${distsrc}

--- a/contrib/gitian-descriptors/gitian-windows.yml
+++ b/contrib/gitian-descriptors/gitian-windows.yml
@@ -23,11 +23,11 @@ remotes:
 - "url": "https://github.com/cosmos/gaia.git"
   "dir": "gaia"
 files:
-- "go1.13.3.linux-amd64.tar.gz"
+- "go1.13.7.linux-amd64.tar.gz"
 script: |
   set -e -o pipefail
 
-  GO_SRC_RELEASE=go1.13.3.linux-amd64
+  GO_SRC_RELEASE=go1.13.7.linux-amd64
   GO_SRC_TARBALL="${GO_SRC_RELEASE}.tar.gz"
   # Compile go and configure the environment
   export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""


### PR DESCRIPTION
- Remove unnecessary -{asm,gc}flags.
- Update to go1.13.7.
- Add multi configuration to build
  for all archs more efficiently.
- Save time on artifacts compression.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))