### PR TITLE
Add testing dockerfile to ibc-alpha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
+TEST_DOCKER_REPO=jackzampolin/gaiatest
 
 export GO111MODULE = on
 
@@ -159,6 +160,14 @@ test-build: build
 
 benchmark:
 	@go test -mod=readonly -bench=. ./...
+
+test-docker:
+	@docker build -f contrib/Dockerfile.test -t ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) .
+	@docker tag ${TEST_DOCKER_REPO}:276e9b7 ${TEST_DOCKER_REPO}:$(shell git rev-parse --abbrev-ref HEAD | sed 's#/#_#g')
+	@docker tag ${TEST_DOCKER_REPO}:276e9b7 ${TEST_DOCKER_REPO}:latest
+	@docker push ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD)
+	@docker push ${TEST_DOCKER_REPO}:$(shell git rev-parse --abbrev-ref HEAD | sed 's#/#_#g')
+	@docker push ${TEST_DOCKER_REPO}:latest
 
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,8 @@ benchmark:
 
 test-docker:
 	@docker build -f contrib/Dockerfile.test -t ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) .
-	@docker tag ${TEST_DOCKER_REPO}:276e9b7 ${TEST_DOCKER_REPO}:$(shell git rev-parse --abbrev-ref HEAD | sed 's#/#_#g')
-	@docker tag ${TEST_DOCKER_REPO}:276e9b7 ${TEST_DOCKER_REPO}:latest
+	@docker tag ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) ${TEST_DOCKER_REPO}:$(shell git rev-parse --abbrev-ref HEAD | sed 's#/#_#g')
+	@docker tag ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) ${TEST_DOCKER_REPO}:latest
 	@docker push ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD)
 	@docker push ${TEST_DOCKER_REPO}:$(shell git rev-parse --abbrev-ref HEAD | sed 's#/#_#g')
 	@docker push ${TEST_DOCKER_REPO}:latest

--- a/cli_test/cli_test.go
+++ b/cli_test/cli_test.go
@@ -1011,7 +1011,7 @@ func TestGaiaCLIEncode(t *testing.T) {
 
 	// Check that the transaction decodes as epxceted
 	var decodedTx auth.StdTx
-	require.Nil(t, cdc.UnmarshalBinaryLengthPrefixed(decodedBytes, &decodedTx))
+	require.Nil(t, cdc.UnmarshalBinaryBare(decodedBytes, &decodedTx))
 	require.Equal(t, "deadbeef", decodedTx.Memo)
 }
 

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -33,4 +33,5 @@ COPY ./contrib/single-node.sh .
 
 EXPOSE 26657
 
+ENTRYPOINT [ "./single-node.sh" ]
 # NOTE: to run this image, docker run -d -p 26657:26657 ./single-node.sh {{chain_id}} {{genesis_account}}

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -1,0 +1,36 @@
+# Simple usage with a mounted data directory:
+# > docker build -t gaia .
+# > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli gaia gaiad init
+# > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli gaia gaiad start
+FROM golang:1.14-alpine AS build-env
+
+# Set up dependencies
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python
+
+# Set working directory for the build
+WORKDIR /go/src/github.com/cosmos/gaia
+
+# Add source files
+COPY . .
+
+# Install minimum necessary dependencies, build Cosmos SDK, remove packages
+RUN apk add --no-cache $PACKAGES && \
+    make tools && \
+    make install
+
+# Final image
+FROM alpine:edge
+
+# Install ca-certificates
+RUN apk add --update ca-certificates
+WORKDIR /root
+
+# Copy over binaries from the build-env
+COPY --from=build-env /go/bin/gaiad /usr/bin/gaiad
+COPY --from=build-env /go/bin/gaiacli /usr/bin/gaiacli
+
+COPY ./contrib/single-node.sh .
+
+EXPOSE 26657
+
+# NOTE: to run this image, docker run -d -p 26657:26657 ./single-node.sh {{chain_id}} {{genesis_account}}

--- a/contrib/single-node.sh
+++ b/contrib/single-node.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+CHAINID=$1
+GENACCT=$2
+
+if [ -z "$1" ]; then
+  echo "Need to input chain id..."
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Need to input genesis account address..."
+  exit 1
+fi
+
+# Build genesis file incl account for passed address
+coins="10000000000stake,100000000000samoleans"
+gaiad init --chain-id $CHAINID $CHAINID
+gaiacli keys add validator --keyring-backend="test"
+gaiad add-genesis-account validator $coins --keyring-backend="test"
+gaiad add-genesis-account $GENACCT $coins --keyring-backend="test"
+gaiad gentx --name validator --keyring-backend="test"
+gaiad collect-gentxs
+
+# Set proper defaults and change ports
+sed -i 's/"leveldb"/"goleveldb"/g' ~/.gaiad/config/config.toml
+sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.gaiad/config/config.toml
+sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' ~/.gaiad/config/config.toml
+sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' ~/.gaiad/config/config.toml
+
+# Start the gaia
+gaiad start --pruning=nothing

--- a/contrib/single-node.sh
+++ b/contrib/single-node.sh
@@ -25,8 +25,8 @@ gaiad collect-gentxs
 # Set proper defaults and change ports
 sed -i 's/"leveldb"/"goleveldb"/g' ~/.gaiad/config/config.toml
 sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.gaiad/config/config.toml
-sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' ~/.gaiad/config/config.toml
-sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' ~/.gaiad/config/config.toml
+sed -i 's/timeout_commit = "5s"/timeout_commit = "500ms"/g' ~/.gaiad/config/config.toml
+sed -i 's/timeout_propose = "3s"/timeout_propose = "500ms"/g' ~/.gaiad/config/config.toml
 
 # Start the gaia
 gaiad start --pruning=nothing

--- a/contrib/single-node.sh
+++ b/contrib/single-node.sh
@@ -25,8 +25,8 @@ gaiad collect-gentxs
 # Set proper defaults and change ports
 sed -i 's/"leveldb"/"goleveldb"/g' ~/.gaiad/config/config.toml
 sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.gaiad/config/config.toml
-sed -i 's/timeout_commit = "5s"/timeout_commit = "500ms"/g' ~/.gaiad/config/config.toml
-sed -i 's/timeout_propose = "3s"/timeout_propose = "500ms"/g' ~/.gaiad/config/config.toml
+sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' ~/.gaiad/config/config.toml
+sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' ~/.gaiad/config/config.toml
 
 # Start the gaia
 gaiad start --pruning=nothing

--- a/lcd_test/helpers.go
+++ b/lcd_test/helpers.go
@@ -205,7 +205,7 @@ func defaultGenesis(config *tmcfg.Config, nValidators int, initAddrs []sdk.AccAd
 			return
 		}
 
-		transaction := auth.NewStdTx([]sdk.Msg{msg}, auth.StdFee{}, []auth.StdSignature{{Signature: sig, PubKey: operPrivKey.PubKey()}}, "")
+		transaction := auth.NewStdTx([]sdk.Msg{msg}, auth.StdFee{}, []auth.StdSignature{{Signature: sig, PubKey: operPrivKey.PubKey().Bytes()}}, "")
 		genTxs = append(genTxs, transaction)
 		valConsPubKeys = append(valConsPubKeys, pubKey)
 		valOperAddrs = append(valOperAddrs, sdk.ValAddress(operAddr))

--- a/lcd_test/lcd_test.go
+++ b/lcd_test/lcd_test.go
@@ -297,7 +297,7 @@ func TestEncodeTx(t *testing.T) {
 
 	// check that the transaction decodes as expected
 	var decodedTx auth.StdTx
-	require.Nil(t, cdc.UnmarshalBinaryLengthPrefixed(decodedBytes, &decodedTx))
+	require.Nil(t, cdc.UnmarshalBinaryBare(decodedBytes, &decodedTx))
 	require.Equal(t, memo, decodedTx.Memo)
 }
 


### PR DESCRIPTION
This adds a `Dockerfile` for testing multiple chains. This is to be used in the relayer integration tests.