### PR TITLE
docker: add user 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Simple usage with a mounted data directory:
 # > docker build -t gaia .
-# > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli gaia gaiad init
-# > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.gaiad:/root/.gaiad -v ~/.gaiacli:/root/.gaiacli gaia gaiad start
+# > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.gaiad:/gaia/.gaiad -v ~/.gaiacli:/gaia/.gaiacli gaia gaiad init
+# > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.gaiad:/gaia/.gaiad -v ~/.gaiacli:/gaia/.gaiacli gaia gaiad start
 FROM golang:alpine AS build-env
 
 # Set up dependencies
@@ -15,15 +15,22 @@ COPY . .
 
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
 RUN apk add --no-cache $PACKAGES && \
-    make tools && \
     make install
 
 # Final image
 FROM alpine:edge
 
+ENV GAIA /gaia
+
 # Install ca-certificates
 RUN apk add --update ca-certificates
-WORKDIR /root
+
+RUN addgroup gaiauser && \
+    adduser -S -G gaiauser gaiauser -h "$GAIA"
+    
+USER gaiauser
+
+WORKDIR $GAIA
 
 # Copy over binaries from the build-env
 COPY --from=build-env /go/bin/gaiad /usr/bin/gaiad


### PR DESCRIPTION
## Description

This PR adds a `USER` to the docker image. This is done for security reasons:

```
When a Dockerfile doesn’t specify a USER, it defaults to executing the container using 
the root user. In practice, there are very few reasons why the container should have 
root privileges. Docker defaults to running containers using the root user. When that 
namespace is then mapped to the root user in the running container, it means that the 
container potentially has root access on the Docker host. Having an application on the 
container run with the root user further broadens the attack surface and enables an 
easy path to privilege escalation if the application itself is vulnerable to exploitation.
``` 
