### PR TITLE
Change ATOMScan blockchain explorer URL

### DIFF
--- a/docs/hub-overview/overview.md
+++ b/docs/hub-overview/overview.md
@@ -44,7 +44,7 @@ These community-maintained web and mobile wallets allow you to store & transfer 
 These block explorers allow you to search, view and analyze Cosmos Hub data&mdash;like blocks, transactions, validators, etc.
 
 * [Anthem](https://anthem.chorus.one)
-* [ATOMScan](https://atomscan.app)
+* [ATOMScan](https://atomscan.com)
 * [Big Dipper](https://cosmos.bigdipper.live)
 * [Cosmos Overview](https://genesislab.net)
 * [Coris](http://coris.network)


### PR DESCRIPTION
We've acquired a new domain to use for our blockchain explorer. Would love if you could update our link!