### PR TITLE
Makefile: fix version string handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
 
-# ascribe tag only if on a release/ branch, otherwise pick branch name and concatenate commit hash
-VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
-ifeq (, $(findstring release/,$(BRANCH)))
-  VERSION = $(BRANCH)-$(COMMIT)
+# don't override user values
+ifeq (,$(VERSION))
+  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  # if VERSION is empty, then populate it with branch's name and raw commit hash
+  ifeq (,$(VERSION))
+    VERSION := $(BRANCH)-$(COMMIT)
+  endif
 endif
 
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')


### PR DESCRIPTION
Most users run builds on tags and not on release
branches. Because of a regression introduced in
651f646b5b9a1, the buildsystem is now assuming that
the opposite is true, therefore it is longer capable
to handle version strings correctly.

Don't use git describe --tags to avoid relying on
non-annotated tags.

BRANCH name detection is ephemeral and unreliable,
and should always be used only as last resort.

Ref: #651

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/main/README.md#merging-a-pr))
