### PR TITLE
ARM64 / AMD64 Multiplatform Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build & Push
 # Build & Push builds the simapp docker image on every push to master and
-# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
+# and pushes the image to https://hub.docker.com/r/tendermint/gaia
 on:
   pull_request:
   push:
@@ -38,18 +38,27 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
+          
+          
+      # Install QEMU 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      # Use buildx instead of build
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
+        
+      # Login so we can push the image
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+          
+      # Using the github action, push the Gaia amd64/arm64 image to Docker Hub
       - name: Publish to Docker Hub
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
+          platform: linux/amd64,linux/arm64


### PR DESCRIPTION
Multiplatform builds and disambiguation

Closes: #726 

## Description

This makes the Docker image a multiplatform one, and clarifies where the Docker image lives.  
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/main/README.md#merging-a-pr))
