### PR TITLE
fix: panic on export zero-height because variable-length addresses

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -157,7 +157,7 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs [
 	counter := int16(0)
 
 	for ; iter.Valid(); iter.Next() {
-		addr := sdk.ValAddress(iter.Key()[1:])
+		addr := sdk.ValAddress(stakingtypes.AddressFromValidatorsKey(iter.Key()))
 		validator, found := app.StakingKeeper.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1014

## Description

Panic occurs when `gaia export --for-zero-height` 

https://github.com/cosmos/gaia/blob/56db57cea8c5c33be4cefdc388829d5f59d0f65e/app/export.go#L160

because of current [`prepForZeroHeightGenesis`](https://github.com/cosmos/gaia/blob/56db57cea8c5c33be4cefdc388829d5f59d0f65e/app/export.go#L160) function using `addr := sdk.ValAddress(iter.Key()[1:])` to casting [variable-length addresses](https://github.com/cosmos/cosmos-sdk/issues/8345),
It should be `addr := sdk.ValAddress(stakingtypes.AddressFromValidatorsKey(iter.Key()))` to cover addresses of length > 20 bytes [ADR-028](https://docs.cosmos.network/master/architecture/adr-028-public-key-addresses.html)


For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/main/README.md#merging-a-pr))
