### PR TITLE
Update broken links in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,13 @@ Types of changes (Stanzas):
 
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
-
+git 
 # Changelog
 
 ## [Unreleased]
 
  * (gaia) Add NewSetUpContextDecorator to anteDecorators
+ * (gaia) Update links in docs [#1125](https://github.com/cosmos/gaia/issues/1125)
 
 ## [v6.0.0] - 2021-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Types of changes (Stanzas):
 
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
-git 
+
 # Changelog
 
 ## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can find an introduction to the Cosmos Hub and how to use the `gaiad` binary
 
 ### 👤 — Node Operators
 ___
-If you're interested in running a node on the current Cosmos Hub, check out the docs to [Join the Cosmos Hub Mainnet](https://github.com/cosmos/gaia/blob/main/docs/gaia-tutorials/join-mainnet.md).
+If you're interested in running a node on the current Cosmos Hub, check out the docs to [Join the Cosmos Hub Mainnet](https://github.com/cosmos/gaia/blob/main/docs/hub-tutorials/join-mainnet.md).
 
 
 <br/>

--- a/contrib/testnets/README.md
+++ b/contrib/testnets/README.md
@@ -3,4 +3,4 @@
 Here contains the files required for automated deployment of either local or remote testnets.
 
 Doing so is best accomplished using the `make` targets. For more information, see the
-[networks documentation](../docs/gaia-tutorials/deploy-testnet.md)
+[networks documentation](../docs/hub-tutorials/deploy-testnet.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,21 +10,21 @@ Welcome to the documentation of the **Cosmos Hub application: `gaia`**.
 
 ## What is Gaia?
 
-- [Intro to the `gaia` software](./gaia-tutorials/what-is-gaia.md)
+- [Intro to the `gaia` software](./getting-started/what-is-gaia.md)
 
 ## Join the Cosmos Hub Mainnet
 
-- [Install the `gaia` application](./gaia-tutorials/installation.md)
-- [Set up a full node and join the mainnet](./gaia-tutorials/join-mainnet.md)
+- [Install the `gaia` application](./getting-started/installation.md)
+- [Set up a full node and join the mainnet](./hub-tutorials/join-mainnet.md)
 - [Upgrade to a validator node](./validators/validator-setup.md)
 
 ## Join the Cosmos Hub Public Testnet
 
-- [Join the testnet](./gaia-tutorials/join-testnet.md)
+- [Join the testnet](./hub-tutorials/join-testnet.md)
 
 ## Setup Your Own `gaia` Testnet
 
-- [Setup your own `gaia` testnet](./gaia-tutorials/deploy-testnet.md)
+- [Setup your own `gaia` testnet](./hub-tutorials/deploy-testnet.md)
 
 ## Additional Resources
 

--- a/docs/delegators/delegator-guide-cli.md
+++ b/docs/delegators/delegator-guide-cli.md
@@ -59,7 +59,7 @@ Please exercise extreme caution!
 [**Download the binaries**]
 Not available yet.
 
-[**Install from source**](../gaia-tutorials/installation.md)
+[**Install from source**](../getting-started/installation.md)
 
 ::: tip
 `gaiad` is used from a terminal. To open the terminal, follow these steps:

--- a/docs/hub-overview/overview.md
+++ b/docs/hub-overview/overview.md
@@ -65,7 +65,7 @@ These block explorers allow you to search, view and analyze Cosmos Hub data&mdas
 
 ## Running a full-node on the Cosmos Hub Mainnet
 
-In order to run a full-node for the Cosmos Hub mainnet, you must first [install `gaiad`](../gaia-tutorials/installation.md). Then, follow [the guide](../gaia-tutorials/join-mainnet.md).
+In order to run a full-node for the Cosmos Hub mainnet, you must first [install `gaiad`](../getting-started/installation.md). Then, follow [the guide](../hub-tutorials/join-mainnet.md).
 
 If you are looking to run a validator node, follow the [validator setup guide](../validators/validator-setup.md).
 

--- a/docs/resources/gaiad.md
+++ b/docs/resources/gaiad.md
@@ -6,7 +6,7 @@ order: 1
 
 ## Gaia Daemon
 
-`gaiad` is the tool that enables you to interact with the node that runs on the Cosmos Hub network, whether you run it yourself or not. Let us set it up properly. In order to install it, follow the [installation procedure](../gaia-tutorials/installation.md).
+`gaiad` is the tool that enables you to interact with the node that runs on the Cosmos Hub network, whether you run it yourself or not. Let us set it up properly. In order to install it, follow the [installation procedure](../getting-started/installation.md).
 
 ### Setting up gaiad
 

--- a/docs/resources/service-providers.md
+++ b/docs/resources/service-providers.md
@@ -44,9 +44,9 @@ A Full Node is a network node that syncs up with the state of the blockchain. It
 
 This section describes the steps to run and interact with a full node for the Cosmos Hub.
 
-First, you need to [install the software](../gaia-tutorials/installation.md).
+First, you need to [install the software](../getting-started/installation.md).
 
-Consider running your own [Cosmos Hub Full Node](../gaia-tutorials/join-mainnet.md).
+Consider running your own [Cosmos Hub Full Node](../hub-tutorials/join-mainnet.md).
 
 ## Command-Line Interface
 
@@ -290,7 +290,7 @@ Flags:
 ## REST API
 
 The [REST API documents](https://cosmos.network/rpc/) list all the available endpoints that you can use to interact
-with your full node. Learn [how to enable the REST API](../gaia-tutorials/join-mainnet.md#enable-the-rest-api) on your full node.
+with your full node. Learn [how to enable the REST API](../hub-tutorials/join-mainnet.md#enable-the-rest-api) on your full node.
 
 ### Listen for Incoming Transactions
 

--- a/docs/translations/es/README.md
+++ b/docs/translations/es/README.md
@@ -22,11 +22,11 @@ Bienvenido a la documentación de la **aplicación para el Hub de Cosmos: `gaia`
 
 ## Únase a la testnet pública del hub de Cosmos
 
-- [Únase a la testnet](./gaia-tutorials/join-testnet.md)
+- [Únase a la testnet](./hub-tutorials/join-testnet.md)
 
 ## Prepare su propia Testnet de `gaia`
 
-- [Prepare su propia Testnet de `gaia`](./gaia-tutorials/deploy-testnet.md)
+- [Prepare su propia Testnet de `gaia`](./hub-tutorials/deploy-testnet.md)
 
 ## Recursos adicionales
 

--- a/docs/validators/validator-faq.md
+++ b/docs/validators/validator-faq.md
@@ -12,7 +12,7 @@ This is work in progress. Mechanisms and values are susceptible to change.
 
 ### What is a Cosmos validator?
 
-The [Cosmos Hub](../gaia-tutorials/what-is-gaia.md) is based on [Tendermint](https://tendermint.com/docs/introduction/what-is-tendermint.html) that relies on a set of validators to secure the network. The role of validators is to run a full node and participate in consensus by broadcasting votes that contain cryptographic signatures signed by the validator's private key. Validators commit new blocks in the blockchain and receive revenue in exchange for their work. Validators must also participate in governance by voting on proposals. Validators are weighted according to their total stake.
+The [Cosmos Hub](../getting-started/what-is-gaia.md) is based on [Tendermint](https://tendermint.com/docs/introduction/what-is-tendermint.html) that relies on a set of validators to secure the network. The role of validators is to run a full node and participate in consensus by broadcasting votes that contain cryptographic signatures signed by the validator's private key. Validators commit new blocks in the blockchain and receive revenue in exchange for their work. Validators must also participate in governance by voting on proposals. Validators are weighted according to their total stake.
 
 ### What is staking?
 
@@ -62,7 +62,7 @@ From all validator candidates that signaled themselves, the 125 validators with 
 
 The testnet is a great environment to test your validator setup before launch.
 
-Testnet participation is a great way to signal to the community that you are ready and able to operate a validator. For details, see [Join the Public Testnet](../gaia-tutorials/join-testnet.md) documentation and the [https://github.com/cosmos/testnets](https://github.com/cosmos/testnets) project on GitHub.
+Testnet participation is a great way to signal to the community that you are ready and able to operate a validator. For details, see [Join the Public Testnet](../hub-tutorials/join-testnet.md) documentation and the [https://github.com/cosmos/testnets](https://github.com/cosmos/testnets) project on GitHub.
 
 ### What are the different types of keys?
 

--- a/docs/validators/validator-setup.md
+++ b/docs/validators/validator-setup.md
@@ -8,7 +8,7 @@ order: 2
 Information on how to join the mainnet (`genesis.json` file and seeds) is held [in our `launch` repo](https://github.com/cosmos/launch/). 
 :::
 
-Before setting up your validator node, make sure you've already gone through the [Full Node Setup](../gaia-tutorials/join-mainnet.md) guide.
+Before setting up your validator node, make sure you've already gone through the [Full Node Setup](../hub-tutorials/join-mainnet.md) guide.
 
 If you plan to use a KMS (key management system), you should go through these steps first: [Using a KMS](kms/kms.md).
 
@@ -20,7 +20,7 @@ If you plan to use a KMS (key management system), you should go through these st
 If you want to become a validator for the Hub's `mainnet`, you should [research security](./security.md).
 :::
 
-You may want to skip the next section if you have already [set up a full-node](../gaia-tutorials/join-mainnet.md).
+You may want to skip the next section if you have already [set up a full-node](../hub-tutorials/join-mainnet.md).
 
 ## Create Your Validator
 


### PR DESCRIPTION
There are a number of broken links due to the refactor of the `gaia-tutorials` folder.  These have been fixed in this pr.

Issue: #1125 