### PR TITLE
Fix links to hub-tutorials

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ order: 2
 
 # Installation
 
-This guide will explain how to install the `gaiad` binary and run the cli. With this binary installed on a server, you can participate on the mainnet as either a [Full Node](./hub-tutorials/join-mainnet.md) or a [Validator](../validators/validator-setup.md).
+This guide will explain how to install the `gaiad` binary and run the cli. With this binary installed on a server, you can participate on the mainnet as either a [Full Node](../hub-tutorials/join-mainnet.md) or a [Validator](../validators/validator-setup.md).
 
 ## Build Requirements
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -120,4 +120,4 @@ The `replace` clause you add to `go.mod` must provide the correct import path:
 
 ## Next
 
-Now you can [join the mainnet](./hub-tutorials/join-mainnet.md), [the public testnet](./hub-tutorials/join-testnet.md) or [create you own testnet](./hub-tutorials/deploy-testnet.md)
+Now you can [join the mainnet](../hub-tutorials/join-mainnet.md), [the public testnet](../hub-tutorials/join-testnet.md) or [create you own testnet](../hub-tutorials/deploy-testnet.md)


### PR DESCRIPTION
Some of the links are broken due to the change of the gaia-tutorials folder. This should fix them.