### PR TITLE
Fix broken and outdated links mentioned in recent github issues

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,9 +40,9 @@ We suggest the following two ways to install Go. Check out the [official docs](h
 
 At the time of this writing, the latest release is `1.17.5`. We're going to download the tarball, extract it to `/usr/local`, and export `GOROOT` to our `$PATH`
 ```bash
-curl -OL https://go.dev/dl/go1.17.5.darwin-amd64.tar.gz
+curl -OL https://go.dev/dl/go1.17.5.linux-amd64.tar.gz
 
-sudo tar -C /usr/local -xvf go1.17.5.darwin-amd64.tar.gz
+sudo tar -C /usr/local -xvf go1.17.5.linux-amd64.tar.gz
 
 export PATH=$PATH:/usr/local/go/bin
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ order: 2
 
 # Installation
 
-This guide will explain how to install the `gaiad` binary and run the cli. With this binary installed on a server, you can participate on the mainnet as either a [Full Node](./hub-tutorials/join-mainnet.md) or a [Validator](../validators/validator-setup.md).
+This guide will explain how to install the `gaiad` binary and run the cli. With this binary installed on a server, you can participate on the mainnet as either a [Full Node](../hub-tutorials/join-mainnet.md) or a [Validator](../validators/validator-setup.md).
 
 ## Build Requirements
 
@@ -38,11 +38,11 @@ We suggest the following two ways to install Go. Check out the [official docs](h
 
 **Ubuntu:**
 
-At the time of this writing, the latest release is `1.17.4`. We're going to download the tarball, extract it to `/usr/local`, and export `GOROOT` to our `$PATH`
+At the time of this writing, the latest release is `1.17.5`. We're going to download the tarball, extract it to `/usr/local`, and export `GOROOT` to our `$PATH`
 ```bash
-curl -OL https://golang.org/dl/go1.17.4.linux-amd64.tar.gz
+curl -OL https://go.dev/dl/go1.17.5.darwin-amd64.tar.gz
 
-sudo tar -C /usr/local -xvf go1.17.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xvf go1.17.5.darwin-amd64.tar.gz
 
 export PATH=$PATH:/usr/local/go/bin
 
@@ -120,4 +120,4 @@ The `replace` clause you add to `go.mod` must provide the correct import path:
 
 ## Next
 
-Now you can [join the mainnet](./hub-tutorials/join-mainnet.md), [the public testnet](./hub-tutorials/join-testnet.md) or [create you own testnet](./hub-tutorials/deploy-testnet.md)
+Now you can [join the mainnet](../hub-tutorials/join-mainnet.md), [the public testnet](../hub-tutorials/join-testnet.md) or [create you own testnet](../hub-tutorials/deploy-testnet.md)

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -4,7 +4,7 @@ order: 3
 
 # Join the Cosmos Hub Mainnet
 
-> Note: The current mainnet (`cosmoshub-4`) has performed the first [in-place store migration](https://docs.cosmos.network/v0.43/architecture/adr-041-in-place-store-migrations.html#adr-041-in-place-store-migrations) upgrade. That means that an [upgrade proposal](https://wallet.keplr.app/#/cosmoshub/governance?detailId=51) was passed to start using the [v5.0.0]() release of the gaia node. As a result the [v4.2.1](https://github.com/cosmos/gaia/releases/tag/v4.2.1) version of the gaia node would panic and stop at block [6910000](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md#Upgrade-will-take-place-July-12,-2021). At that point node operators installed the [v5.0.5](https://github.com/cosmos/gaia/releases/tag/v5.0.5) version of the gaia node and then started the node again. This type of upgrade preserves the same `chain-id` but is otherwise similar to a traditional hub upgrade, meaning historical state is lost after the upgrade takes place (still accessible of course by a v4.2.1 full node).
+> Note: The current mainnet (`cosmoshub-4`) has performed the first [in-place store migration](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md) upgrade. That means that an [upgrade proposal](https://wallet.keplr.app/#/cosmoshub/governance?detailId=51) was passed to start using the [v5.0.0]() release of the gaia node. As a result the [v4.2.1](https://github.com/cosmos/gaia/releases/tag/v4.2.1) version of the gaia node would panic and stop at block [6910000](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md#Upgrade-will-take-place-July-12,-2021). At that point node operators installed the [v5.0.5](https://github.com/cosmos/gaia/releases/tag/v5.0.5) version of the gaia node and then started the node again. This type of upgrade preserves the same `chain-id` but is otherwise similar to a traditional hub upgrade, meaning historical state is lost after the upgrade takes place (still accessible of course by a v4.2.1 full node).
 >
 > **In order to sync a gaia node from genesis the upgrade process outline above and [in more detail here](https://github.com/cosmos/mainnet) will need to take place.**
 >
@@ -16,7 +16,7 @@ order: 3
 
 This Quickstart tutorial completes the following actions:
 
-* Ensure that you have [compilation prerequisites](./getting-started/installation.md)
+* Ensure that you have [compilation prerequisites](../getting-started/installation.md)
 * Compile gaia
 * Give your node a moniker and configure it
 * Download compressed genesis state
@@ -120,7 +120,10 @@ gaiad start
 
 Your node needs to know how to find peers. You'll need to add healthy seed nodes to `$HOME/.gaia/config/config.toml`. The [`launch`](https://github.com/cosmos/launch) repo contains links to some seed nodes.
 
-If those seeds aren't working, you can find more seeds and persistent peers on a Cosmos Hub explorer (a list can be found on the [launch page](https://cosmos.network/launch)).
+If those seeds aren't working, you can find more seeds and persistent peers on a Cosmos Hub explorer (try [mintscan]() or [bigdipper]()). The Hub team is working on publishing a more 
+
+
+(a list can be found on the [launch page](https://cosmos.network/launch)).
 
 
 
@@ -178,7 +181,7 @@ Check that everything is running smoothly:
 gaiad status
 ```
 
-View the status of the network with the [Cosmos Explorer](https://cosmos.network/launch).
+View the status of the network with the [Cosmos Explorer](https://www.mintscan.io/cosmos).
 
 ## Enable the REST API
 

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -120,11 +120,7 @@ gaiad start
 
 Your node needs to know how to find peers. You'll need to add healthy seed nodes to `$HOME/.gaia/config/config.toml`. The [`launch`](https://github.com/cosmos/launch) repo contains links to some seed nodes.
 
-If those seeds aren't working, you can find more seeds and persistent peers on a Cosmos Hub explorer (try [mintscan]() or [bigdipper]()). The Hub team is working on publishing a more 
-
-
-(a list can be found on the [launch page](https://cosmos.network/launch)).
-
+If those seeds aren't working, you can find more seeds and persistent peers on a Cosmos Hub explorer (try [mintscan](https://www.mintscan.io/cosmos) or [bigdipper](https://cosmos.bigdipper.live/)). The Hub team is currently working on a forthcoming guide with additional detail.
 
 
 ## A Note on Gas and Fees


### PR DESCRIPTION
Some of the last few github issues have mentioned broken links or have referenced outdated links on the hub docs. This is by no means all of them but this is the first batch to be corrected. 