### PR TITLE
Update joining mainnet documentation

### DIFF
--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -1,3 +1,7 @@
+<!--
+order: 3
+-->
+
 # Join the Cosmos Hub Mainnet
 
 The current Cosmos Hub mainnet`cosmoshub-4`is operating after its most recent [Vega upgrade `V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). This guide includes instructions for joining the mainnet either as an archive/full node or a pruned node. For instructions to join as a validator, please also see the [validator instructions](https://hub.cosmos.network/main/validators/overview.html#).

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -75,7 +75,7 @@ Running a full archive node can be resource intensive as the full  current `cosm
 
 ## General Configuration
 
-Before choosing a method of syncing a node, make sure to walk through the basic setup and configuration. Operators will need to initialize gaiad, download the genesis file for `cosmoshub-4`, and set persistent peers and/or seeds for startup.
+Make sure to walk through the basic setup and configuration. Operators will need to initialize `gaiad`, download the genesis file for `cosmoshub-4`, and set persistent peers and/or seeds for startup.
 
 ### Initialize Chain
 
@@ -148,6 +148,8 @@ The initial recommended `min-gas-prices` is `0.0025uatom`, but this can be chang
 
 ### Pruning of State
 
+> **Note**: This is an optional configuration.
+
 There are four strategies for pruning state. These strategies apply only to state and do not apply to block storage. A node operator may want to consider custom pruning if node storage is a concern or there is an interest in running an archive node.
 
 To set pruning, adjust the `pruning` parameter in the `~/.gaia/config/app.toml` file.
@@ -181,6 +183,8 @@ Passing a flag when starting `gaia` will always override settings in the `app.to
 
 ### REST API
 
+> **Note**: This is an optional configuration.
+
 By default, the REST API is disabled. To enable the REST API, edit the `~/.gaia/config/app.toml` file, and set `enable` to `true` in the `[api]` section.
 
 ```
@@ -200,6 +204,8 @@ Optionally activate swagger by setting `swagger` to `true` or change the port of
 After restarting the application, access the REST API on `<NODE IP>:1317`.
 
 ### GRPC
+
+> **Note**: This is an optional configuration.
 
 By default, gRPC is enabled on port `9090`. The `~/.gaia/config/app.toml` file is where changes can be made in the gRPC section. To disable the gRPC endpoint, set `enable` to `false`. To change the port, use the `address` parameter.
 

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -18,6 +18,7 @@ For instructions to join as a validator, please also see the [Validator Guide](h
 <!-- DON'T FORGET TO KEEP INDEX UP TO DATE -->
 - [Explorers](#explorers)
 - [Getting Started](#getting-started)
+- [Hardware Requirements](#hardware)
 - [General Configuration](#general-configuration)
     - [Initialize Chain](#initialize-chain)
     - [Genesis File](#genesis-file)
@@ -30,8 +31,7 @@ For instructions to join as a validator, please also see the [Validator Guide](h
     - [Blocksync](#blocksync)
     - [State Sync](#state-sync)
     - [Quicksync](#quicksync)
-- [Snapshots](#snapshots)
-- [Hardware Requirements](#hardware)
+- [Snapshots](#snapshots)=
 - [Releases](#releases-amp-upgrades)
 - [Cosmovisor](#cosmovisor)
 - [Running via Background Process](#running-via-background-process)
@@ -59,6 +59,18 @@ Make sure the following prerequisites are completed:
 - Choose the proper hardware/server configuration. See the [hardware guide](#hardware).
 - Ensure Gaia is properly installed. See the [installation guide](https://hub.cosmos.network/main/getting-started/installation.html) for a walkthrough.
 - Follow the [configuration guide](#General-Configuration) to intialize and prepare the node to sync with the network.
+
+
+## Hardware
+Running a full archive node can be resource intensive as the full  current `cosmoshub-4` state is over `1.4TB`. For those who wish to run state sync or use quicksync, the following hardware configuration is recommended:
+
+| Node Type     | RAM                   | Storage     |
+| -----------   | --------------------- | ----------- |
+| Validator     | 32GB                  | 500GB-2TB*  |
+| Full          | 16GB                  | 2TB         |
+| Default       | 16GB                  | 1TB         |
+
+\* Storage size for validators will depend on level of pruning.
 
 
 ## General Configuration
@@ -347,19 +359,6 @@ snapshot-interval = 1000
 # snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
 snapshot-keep-recent = 10
 ```
-
-
-## Hardware
-Running a full archive node can be resource intensive as the full  current `cosmoshub-4` state is over `1.4TB`. For those who wish to run state sync or use quicksync, the following hardware configuration is recommended:
-
-| Node Type     | RAM                   | Storage     |
-| -----------   | --------------------- | ----------- |
-| Validator     | 16GB (32 Recommended) | 500GB-2TB*  |
-| Full          | 8GB (16 Recommended)  | 2TB         |
-| Default       | 8GB (16 Recommended)  | 1TB         |
-
-\* Storage size for validators will depend on level of pruning.
-
 
 ## Releases & Upgrades
 **See all [Gaia Releases](https://github.com/cosmos/gaia/releases)**

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -45,7 +45,7 @@ There are many explorers for the Cosmos Hub. For reference while setting up a no
 Before syncing a node, make sure the following prerequisites are completed:
 - Choose the proper hardware/server configuration. See the [hardware guide](#hardware).
 - Ensure Gaia is properly installed. See the [installation guide](https://hub.cosmos.network/main/getting-started/installation.html) for a walkthrough.
-- Compile the Gaia binary. The version of Gaia will depend on which way the node is synced. See [releases](#releases) for more information on the appropriate version to build.
+- Compile the Gaia binary (also in the installation guide). The version of Gaia will depend on [which way the node is synced](#Choosing-a-Sync-Mode). If syncing from scratch checkout version [`v4.2.1`](https://github.com/cosmos/gaia/releases/tag/v4.2.1). If syncing via state sync, checkout the [latest release](https://github.com/cosmos/gaia/releases/tag/v6.0.0). If unsure, see [releases](#Releases-amp-Upgrades) for more information on the appropriate version to build.
 - Follow the [configuration guide](#General-Configuration) to intialize and prepare the node to sync with the network.
 
 
@@ -80,7 +80,7 @@ mv genesis.cosmoshub-4.json ~/.gaia/config/genesis.json
 
 ### Seeds & Peers
 
-Upon startup the node will need to connect to peers. If there are specific nodes a node operator is interested in setting as seeds or as persistent peers, this can be configured in `$HOME/.gaia/config/config.toml`
+Upon startup the node will need to connect to peers. If there are specific nodes a node operator is interested in setting as seeds or as persistent peers, this can be configured in `~/.gaia/config/config.toml`
 
 ```
 # Comma separated list of seed nodes to connect to
@@ -110,7 +110,7 @@ The transaction `fees` are the product of `gas` and `gasPrice`. The higher the `
 
 **For mainnet, the recommended `gas-prices` is `0.0025uatom`.**
 
-A full-node keeps unconfirmed transactions in its mempool. In order to protect it from spam, it is better to set a `minimum-gas-prices` that the transaction must meet in order to be accepted in your node's mempool. This parameter can be set in the following file `~/.gaia/config/app.toml`.
+A full-node keeps unconfirmed transactions in its mempool. In order to protect it from spam, it is better to set a `minimum-gas-prices` that the transaction must meet in order to be accepted in the node's mempool. This parameter can be set in  `~/.gaia/config/app.toml`.
 
 ```
 # The minimum gas prices a validator is willing to accept for processing a
@@ -150,9 +150,9 @@ pruning-keep-every = "1000"
 pruning-interval = "10"
 ```
 
-Passing a flag when starting `gaia` will always override settings in the `app.toml` file, if you would like to change your node to the `everything` mode then you can pass the `---pruning everything` flag when you call `gaiad start`.
+Passing a flag when starting `gaia` will always override settings in the `app.toml` file. To change the node's pruning setting to `everything` mode then pass the `---pruning everything` flag when running `gaiad start`.
 
-> **Note**: When you are pruning state it will not be possible to query the heights that are not in the node's store.
+> **Note**: If running the node with pruned state, it will not be possible to query the heights that are not in the node's store.
 
 ### REST API
 
@@ -171,12 +171,12 @@ swagger = false
 address = "tcp://0.0.0.0:1317"
 ```
 
-Optionally, you can activate swagger by setting `swagger` to `true` or change the port of the REST API in the parameter `address`.
-After restarting your application, you can access the REST API on `<NODE IP>:1317`.
+Optionally activate swagger by setting `swagger` to `true` or change the port of the REST API in the parameter `address`.
+After restarting the application, access the REST API on `<NODE IP>:1317`.
 
 ### GRPC
 
-By default, gRPC is enabled on port `9090`. In the `~/.gaia/config/app.toml` file, you can make changes in the gRPC section. To disable the gRPC endpoint, set `enable` to `false`. To change the port, use the `address` parameter.
+By default, gRPC is enabled on port `9090`. The `~/.gaia/config/app.toml` file is where changes can be made in the gRPC section. To disable the gRPC endpoint, set `enable` to `false`. To change the port, use the `address` parameter.
 
 ```
 ###############################################################################
@@ -196,9 +196,9 @@ There are three main ways to sync a node on the Cosmos Hub. The way a node opera
 
 If a node operator wishes to run a full/archive node, it is possible to start from scratch but will take a significant amount of time to catch up. Node operators not concerned with rebuilding original state from the beginning of `cosmoshub-4` can also leverage [Quicksync](#Quicksync)'s available archive history.
 
-For operators interested in bootstrapping a pruned node, either [Quicksync](#Quicksync) or [State sync](#State-sync) would be sufficient.
+For operators interested in bootstrapping a pruned node, either [Quicksync](#Quicksync) or [State Sync](#State-Sync) would be sufficient.
 
-Make sure to consult the [hardware](#hardware) section for guidance on the best configuration for the type of node operating.
+Make sure to consult the [hardware](#Hardware) section for guidance on the best configuration for the type of node operating.
 
 ### Sync from scratch
 
@@ -216,9 +216,9 @@ The node will begin rebuilding state until it hits the first upgrade height at b
 
 Enabling state sync can be one of the most efficient ways to bootstrap a node. On startup, the node will ask its peers for available snapshots. Once a snapshot has been accepted, it will begin requesting snapshot chunks from peers. Once the snapshot is verified, the node will begin to process blocks in realtime until it catches up with the head of the chain. For more information on state sync, see [Tendermint's documentation](https://docs.tendermint.com/master/spec/p2p/messages/state-sync.html).
 
-To enable state, visit an explorer to get a recent block height and corresponding hash. A node operator can choose any height/hash in the current bonding period, but as the recommended snapshot period is `1000` blocks, it is advised to choose something close to`height - 1000`.
+To enable state sync, visit an explorer to get a recent block height and corresponding hash. A node operator can choose any height/hash in the current bonding period, but as the recommended snapshot period is `1000` blocks, it is advised to choose something close to `current height - 1000`.
 
-With the block height and hash selected, update the configuration in `~/.gaia/config/config.toml` to set `enable = true`, and populate the `trust_height` and `trust_hash`. Node operators can configure the rpc servers to a preferred provider, but there must be at least two entries. It is important that these are two rpc servers the node operator trusts to verify component parts of the chain state. While not reccommended, uniqueness is not currently enforced, so it is possible to duplicate the same server in the list and still sync successfully.
+With the block height and hash selected, update the configuration in `~/.gaia/config/config.toml` to set `enable = true`, and populate the `trust_height` and `trust_hash`. Node operators can configure the rpc servers to a preferred provider, but there must be at least two entries. It is important that these are two rpc servers the node operator trusts to verify component parts of the chain state. While not recommended, uniqueness is not currently enforced, so it is possible to duplicate the same server in the list and still sync successfully.
 
 > **Note**: In the future, the RPC server requirement will be deprecated as state sync is [moved to the p2p layer in Tendermint 0.35](https://github.com/tendermint/tendermint/issues/6491).
 
@@ -405,13 +405,13 @@ Export state with:
 gaiad export > [filename].json
 ```
 
-You can also export state from a particular height (at the end of processing the block of that height):
+It is also possible to export state from a particular height (at the end of processing the block of that height):
 
 ```bash
 gaiad export --height [height] > [filename].json
 ```
 
-If you plan to start a new network from the exported state, export with the `--for-zero-height` flag:
+If planning to start a new network from the exported state, export with the `--for-zero-height` flag:
 
 ```bash
 gaiad export --height [height] --for-zero-height > [filename].json
@@ -421,19 +421,13 @@ gaiad export --height [height] --for-zero-height > [filename].json
 ## Verify Mainnet
 
 Help to prevent a catastrophe by running invariants on each block on your full
-node. In essence, by running invariants you ensure that the state of mainnet is
-the correct expected state. One vital invariant check is that no atoms are
-being created or destroyed outside of expected protocol, however there are many
-other invariant checks each unique to their respective module. Because invariant checks
-are computationally expensive, they are not enabled by default. To run a node with
-these checks start your node with the assert-invariants-blockly flag:
+node. In essence, by running invariants the node operator ensures that the state of mainnet is the correct expected state. One vital invariant check is that no atoms are being created or destroyed outside of expected protocol, however there are many other invariant checks each unique to their respective module. Because invariant checks are computationally expensive, they are not enabled by default. To run a node with these checks start your node with the assert-invariants-blockly flag:
 
 ```bash
 gaiad start --assert-invariants-blockly
 ```
 
-If an invariant is broken on your node, your node will panic and prompt you to send
-a transaction which will halt mainnet. For example the provided message may look like:
+If an invariant is broken on the node, it will panic and prompt the operator to send a transaction which will halt mainnet. For example the provided message may look like:
 
 ```bash
 invariant broken:

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -1,130 +1,98 @@
-<!--
-order: 3
--->
-
 # Join the Cosmos Hub Mainnet
 
-> Note: The current mainnet (`cosmoshub-4`) has performed the first [in-place store migration](https://docs.cosmos.network/v0.43/architecture/adr-041-in-place-store-migrations.html#adr-041-in-place-store-migrations) upgrade. That means that an [upgrade proposal](https://wallet.keplr.app/#/cosmoshub/governance?detailId=51) was passed to start using the [v5.0.0]() release of the gaia node. As a result the [v4.2.1](https://github.com/cosmos/gaia/releases/tag/v4.2.1) version of the gaia node would panic and stop at block [6910000](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md#Upgrade-will-take-place-July-12,-2021). At that point node operators installed the [v5.0.5](https://github.com/cosmos/gaia/releases/tag/v5.0.5) version of the gaia node and then started the node again. This type of upgrade preserves the same `chain-id` but is otherwise similar to a traditional hub upgrade, meaning historical state is lost after the upgrade takes place (still accessible of course by a v4.2.1 full node).
->
-> **In order to sync a gaia node from genesis the upgrade process outline above and [in more detail here](https://github.com/cosmos/mainnet) will need to take place.**
->
-> _To quickly sync a Cosmos Hub node it's recommended that you use the [cosmos.quicksync.io](https://cosmos.quicksync.io/) snapshots._
+The current Cosmos Hub mainnet`cosmoshub-4`is operating after its most recent [Vega upgrade `V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). This guide includes instructions for joining the mainnet either as an archive/full node or a pruned node. For instructions to join as a validator, please also see the [validator instructions](https://hub.cosmos.network/main/validators/overview.html#).
 
-## Quickstart
+### Overview
 
-**Get Ready**
+- [Explorers](#Explorers)
+- [Getting Started](#Getting-Started)
+- [General Configuration](#General-Configuration)
+    - [Initialize Chain](#Initialize-Chain)
+    - [Genesis File](#Genesis-File)
+    - [Seeds & Peers](#Seeds-amp-Peers)
+    - [Gas & Fees](#Gas-amp-Fees)
+    - [Pruning of State](#Pruning-of-State)
+    - [REST API](#REST-API)
+    - [GRPC](#GRPC)
+- [Choosing a Sync Mode](#Choosing-a-Sync-Mode)
+    - [Sync from Scratch (Full/Archive Node)](#Sync-from-scratch)
+    - [State Sync](#State-Sync)
+    - [Quicksync](#Quicksync)
+- [Snapshots](#Snapshots)
+- [Hardware Requirements](#Hardware)
+- [Releases](#Releases-amp-Upgrades)
+- [Cosmovisor](#Cosmovisor)
+- [Running via Background Process](#Running-via-Background-Process)
+- [Exporting State](#Exporting-State)
+- [Verify Mainnet](#Verify-Mainnet)
 
-This Quickstart tutorial completes the following actions:
+### Background
 
-* Ensure that you have [compilation prerequisites](./getting-started/installation.md)
-* Compile gaia
-* Give your node a moniker and configure it
-* Download compressed genesis state
-* Put the `genesis.json` file in the correct location
+The current Cosmos Hub mainnet `cosmoshub-4` has been performing in place store migration upgrades as of the [Delta Upgrade](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md) July 2021. The most recent upgrade was [Vega](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-vega-upgrade.md) December 2021. This type of upgrade preserves the same chain-id but is otherwise similar to a traditional hub upgrade, meaning historical state is lost after the upgrade takes place (still accessible of course by a v4.2.1 full node). Visit the [migration section](https://github.com/cosmos/gaia/tree/main/docs/migration) of the Hub's docs for more information on previous chain migrations.
 
+
+## Explorers
+
+There are many explorers for the Cosmos Hub. For reference while setting up a node, here are a few recommendations:
+
+- [Mintscan](https://www.mintscan.io/cosmos)
+- [Big Dipper](https://cosmos.bigdipper.live/)
+- [Hubble](https://hubble.figment.io/cosmos/chains/cosmoshub-4)
+
+
+## Getting Started
+
+Before syncing a node, make sure the following prerequisites are completed:
+- Choose the proper hardware/server configuration. See the [hardware guide](#hardware).
+- Ensure Gaia is properly installed. See the [installation guide](https://hub.cosmos.network/main/getting-started/installation.html) for a walkthrough.
+- Compile the Gaia binary. The version of Gaia will depend on which way the node is synced. See [releases](#releases) for more information on the appropriate version to build.
+- Follow the [configuration guide](#General-Configuration) to intialize and prepare the node to sync with the network.
+
+
+## General Configuration
+
+Before choosing a method of syncing a node, make sure to walk through the basic setup and configuration. Operators will need to initialize gaiad, download the genesis file for `cosmoshub-4`, and set persistent peers and/or seeds for startup.
+
+### Initialize Chain
+
+Choose a custom moniker for the node and initialize. By default, the `init` command creates the `~/.gaia` directory with subfolders `config` and `data`. In the `/config` directory, the most important files for configuration are `app.toml` and `config.toml`.
 ```bash
-git clone -b v4.2.1 https://github.com/cosmos/gaia
-cd gaia
-make install
-gaiad init chooseanicehandle
+gaiad init <custom-moniker>
+```
+
+> **Note**: Monikers can contain only ASCII characters. Using Unicode characters is not supported and renders the node unreachable.
+
+The `moniker` can be edited in the `~/.gaia/config/config.toml` file:
+
+```
+# A custom human readable name for this node
+moniker = "<custom_moniker>"
+```
+
+### Genesis File
+
+Once the node is initialized, download the genesis file and move to the `/config` directory of the Gaia home directory.
+```bash
 wget https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz
 gzip -d genesis.cosmoshub-4.json.gz
 mv genesis.cosmoshub-4.json ~/.gaia/config/genesis.json
 ```
 
-**Go**
-Starts Gaia
-```bash
-gaiad start --p2p.seeds bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656,366ac852255c3ac8de17e11ae9ec814b8c68bddb@51.15.94.196:26656 --x-crisis-skip-assert-invariants
-```
-Now wait until the chain reaches block height 6910000. It will panic and you will see a message like:
-```
-ERR UPGRADE "Gravity-DEX" NEEDED at height: 6910000: v5.0.0-4760cf1f1266accec7a107f440d46d9724c6fd08
+### Seeds & Peers
 
-panic: UPGRADE "Gravity-DEX" NEEDED at height: 6910000: v5.0.0-4760cf1f1266accec7a107f440d46d9724c6fd08
-```
-Then you should run the following commands:
-```bash
-git checkout -b v5.0.5
-make install
-gaiad start --x-crisis-skip-assert-invariants --p2p.seeds bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656
-```
-
-Note:  If your node is unable to connect to any of the seeds listed here, you can find seeds and peers in [this document](https://hackmd.io/@KFEZk8oMTz6vBlwADz0M4A/BkKEUOsZu#) maintained by community members, and at [Atlas](https://atlas.cosmos.network/nodes), which is automatically generated by crawling the network.
-
-To save those seeds to your settings, put the comma-separated list format seeds in `~/.gaia/config/config.toml` in the p2p section under seeds.
-
-## Manual Setup of a new Node
-
-These instructions are for setting up a brand new full node from scratch.
-
-Make sure to have the [latest gaia version installed](./join-mainnet.md).
-First, initialize the node.
-
-```bash
-gaiad init <your_custom_moniker>
-```
-
-**Note**
-Monikers can contain only ASCII characters. Using Unicode characters is not supported and renders your node unreachable.
-
-By default, the `init` command creates your `~/.gaia` directory with subfolders `config` and `data`.
-In the `config` directory, the most important files for configuration are `app.toml` and `config.toml`.
-
-You can edit the `moniker` in the `~/.gaia/config/config.toml` file:
-
-```toml
-# A custom human readable name for this node
-moniker = "<your_custom_moniker>"
-```
-
-For optimized node performance, edit the `~/.gaia/config/app.toml` file to enable the anti-spam mechanism and reject incoming transactions with less than the minimum gas prices:
+Upon startup the node will need to connect to peers. If there are specific nodes a node operator is interested in setting as seeds or as persistent peers, this can be configured in `$HOME/.gaia/config/config.toml`
 
 ```
-# This is a TOML config file.
-# For more information, see https://github.com/toml-lang/toml
+# Comma separated list of seed nodes to connect to
+seeds = "<seed node id 1>@<seed node address 1>:26656,<seed node id 2>@<seed node address 2>:26656"
 
-##### main base config options #####
-
-# The minimum gas prices a validator is willing to accept for processing a
-# transaction. A transaction's fees must meet the minimum of any denomination
-# specified in this config (for example, 10uatom).
-
-minimum-gas-prices = "0.0025uatom"
+# Comma separated list of nodes to keep persistent connections to
+persistent_peers = "<node id 1>@<node address 1>:26656,<node id 2>@<node address 2>:26656"
 ```
 
-Your full node has been initialized!
+Alternatively, node operators can also download the [Quicksync address book]( https://quicksync.io/addrbook.cosmos.json). Make sure this is moved to `~/.gaia/config/addrbook.json`.
 
-## Genesis & Seeds
-
-### Copy the Genesis File
-
-Fetch the mainnet's `genesis.json` file into `gaiad`'s config directory.
-
-```bash
-mkdir -p $HOME/.gaia/config
-wget https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz
-gzip -d genesis.cosmoshub-4.json.gz
-mv genesis.cosmoshub-4.json $HOME/.gaia/config
-```
-
-If you want to connect to the public testnet instead, click [here](./join-testnet.md)
-
-To verify the correctness of the configuration run:
-
-```bash
-gaiad start
-```
-
-### Add Seed Nodes
-
-Your node needs to know how to find peers. You'll need to add healthy seed nodes to `$HOME/.gaia/config/config.toml`. The [`launch`](https://github.com/cosmos/launch) repo contains links to some seed nodes.
-
-If those seeds aren't working, you can find more seeds and persistent peers on a Cosmos Hub explorer (a list can be found on the [launch page](https://cosmos.network/launch)).
-
-
-
-## A Note on Gas and Fees
+### Gas & Fees
 
 On Cosmos Hub mainnet, the accepted denom is `uatom`, where `1atom = 1.000.000uatom`
 
@@ -134,23 +102,29 @@ Transactions on the Cosmos Hub network need to include a transaction fee in orde
 fees = ceil(gas * gasPrices)
 ```
 
-The `gas` is dependent on the transaction. Different transaction require different amount of `gas`. The `gas` amount for a transaction is calculated as it is being processed, but there is a way to estimate it beforehand by using the `auto` value for the `gas` flag. Of course, this only gives an estimate. You can adjust this estimate with the flag `--gas-adjustment` (default `1.0`) if you want to be sure you provide enough `gas` for the transaction.
+The `gas` is dependent on the transaction. Different transaction require different amount of `gas`. The `gas` amount for a transaction is calculated as it is being processed, but there is a way to estimate it beforehand by using the `auto` value for the `gas` flag. Of course, this only gives an estimate. This estimate is adjustable with the flag `--gas-adjustment` (default `1.0`) to ensure enough `gas` is provided for the transaction.
 
 The `gasPrice` is the price of each unit of `gas`. Each validator sets a `min-gas-price` value, and will only include transactions that have a `gasPrice` greater than their `min-gas-price`.
 
-The transaction `fees` are the product of `gas` and `gasPrice`. As a user, you have to input 2 out of 3. The higher the `gasPrice`/`fees`, the higher the chance that your transaction will get included in a block.
+The transaction `fees` are the product of `gas` and `gasPrice`. The higher the `gasPrice`/`fees`, the higher the chance that your transaction will get included in a block.
 
-For mainnet, the recommended `gas-prices` is `0.0025uatom`.
+**For mainnet, the recommended `gas-prices` is `0.0025uatom`.**
 
-## Set `minimum-gas-prices`
+A full-node keeps unconfirmed transactions in its mempool. In order to protect it from spam, it is better to set a `minimum-gas-prices` that the transaction must meet in order to be accepted in your node's mempool. This parameter can be set in the following file `~/.gaia/config/app.toml`.
 
-Your full-node keeps unconfirmed transactions in its mempool. In order to protect it from spam, it is better to set a `minimum-gas-prices` that the transaction must meet in order to be accepted in your node's mempool. This parameter can be set in the following file `~/.gaia/config/app.toml`.
+```
+# The minimum gas prices a validator is willing to accept for processing a
+# transaction. A transaction's fees must meet the minimum of any denomination
+# specified in this config (e.g. 0.25token1;0.0001token2).
+minimum-gas-prices = "0.0025uatom"
+```
 
-The initial recommended `min-gas-prices` is `0.0025uatom`, but you might want to change it later.
+The initial recommended `min-gas-prices` is `0.0025uatom`, but this can be changed later.
 
-## Pruning of State
+### Pruning of State
 
-There are four strategies for pruning state. These strategies apply only to state and do not apply to block storage.
+There are four strategies for pruning state. These strategies apply only to state and do not apply to block storage. A node operator may want to consider custom pruning if node storage is a concern or there is an interest in running an archive node.
+
 To set pruning, adjust the `pruning` parameter in the `~/.gaia/config/app.toml` file.
 The following pruning state settings are available:
 
@@ -160,31 +134,31 @@ The following pruning state settings are available:
 4. `custom`: Specify pruning settings with the `pruning-keep-recent`, `pruning-keep-every`, and `pruning-interval` parameters.
 
 By default, every node is in `default` mode which is the recommended setting for most environments.
-If you would like to change your nodes pruning strategy then you must do so when the node is initialized. Passing a flag when starting `gaia` will always override settings in the `app.toml` file, if you would like to change your node to the `everything` mode then you can pass the `---pruning everything` flag when you call `gaiad start`.
+If a node operator wants to change their node's pruning strategy then this **must** be done before the node is initialized.
 
-> Note: When you are pruning state you will not be able to query the heights that are not in your store.
+In `~/.gaia/config/app.toml`
+```
+# default: the last 100 states are kept in addition to every 500th state; pruning at 10 block intervals
+# nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
+# everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
+# custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'
+pruning = "custom"
 
-## Run a Full Node
-
-Start the full node with this command:
-
-```bash
-gaiad start
+# These are applied if and only if the pruning strategy is custom.
+pruning-keep-recent = "10"
+pruning-keep-every = "1000"
+pruning-interval = "10"
 ```
 
-Check that everything is running smoothly:
+Passing a flag when starting `gaia` will always override settings in the `app.toml` file, if you would like to change your node to the `everything` mode then you can pass the `---pruning everything` flag when you call `gaiad start`.
 
-```bash
-gaiad status
-```
+> **Note**: When you are pruning state it will not be possible to query the heights that are not in the node's store.
 
-View the status of the network with the [Cosmos Explorer](https://cosmos.network/launch).
-
-## Enable the REST API
+### REST API
 
 By default, the REST API is disabled. To enable the REST API, edit the `~/.gaia/config/app.toml` file, and set `enable` to `true` in the `[api]` section.
 
-```toml
+```
 ###############################################################################
 ###                           API Configuration                             ###
 ###############################################################################
@@ -198,13 +172,13 @@ address = "tcp://0.0.0.0:1317"
 ```
 
 Optionally, you can activate swagger by setting `swagger` to `true` or change the port of the REST API in the parameter `address`.
-After restarting your application, you can access the REST API on `YOURNODEIP:1317`.
+After restarting your application, you can access the REST API on `<NODE IP>:1317`.
 
-## GRPC Configuration
+### GRPC
 
 By default, gRPC is enabled on port `9090`. In the `~/.gaia/config/app.toml` file, you can make changes in the gRPC section. To disable the gRPC endpoint, set `enable` to `false`. To change the port, use the `address` parameter.
 
-```toml
+```
 ###############################################################################
 ###                           gRPC Configuration                            ###
 ###############################################################################
@@ -215,16 +189,169 @@ enable = true
 address = "0.0.0.0:9090"
 ```
 
-## Upgrades
 
-To be best prepared for eventual upgrades, it is recommended to setup [Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html), a small process manager,  which can swap in new `gaiad` binaries. Read more about setting this up [here](upgrade-node.md).
+## Choosing a Sync Mode
 
-## Background Process
+There are three main ways to sync a node on the Cosmos Hub. The way a node operator will want to sync is partially dependent on the type of node they will operate. This guide will focus on two types of common nodes; archive/full and pruned. For further information on syncing to run a validator node, see the section on [Validators](https://hub.cosmos.network/main/validators/overview.html).
 
-To run the node in a background process with automatic restarts, you can use a service manager like `systemd`. To set this up run the following:
+If a node operator wishes to run a full/archive node, it is possible to start from scratch but will take a significant amount of time to catch up. Node operators not concerned with rebuilding original state from the beginning of `cosmoshub-4` can also leverage [Quicksync](#Quicksync)'s available archive history.
+
+For operators interested in bootstrapping a pruned node, either [Quicksync](#Quicksync) or [State sync](#State-sync) would be sufficient.
+
+Make sure to consult the [hardware](#hardware) section for guidance on the best configuration for the type of node operating.
+
+### Sync from scratch
+
+Syncing from scratch is possible by starting the chain from the beginning of `cosmoshub-4` and either manually upgrading the chain or setting up [Cosmovisor](#Cosmovisor) to upgrade automatically. Node operators syncing from scratch will need to navigate two upgrades, Delta and Vega. For more information on performing the manual upgrades, see [Releases & Upgrades](#Releases-amp=-Upgrades).
+
+Start Gaia to begin syncing with the `skip-invariants` flag. For more information on this see [Verify Mainnet](#Verify-Mainnet).
+```bash
+gaiad start --x-crisis-skip-assert-invariants
+
+```
+
+The node will begin rebuilding state until it hits the first upgrade height at block `6910000`. If Cosmovisor is set up then there's nothing else to do besides wait, otherwise the node operator will need to perform the manual upgrade twice.
+
+### State Sync
+
+Enabling state sync can be one of the most efficient ways to bootstrap a node. On startup, the node will ask its peers for available snapshots. Once a snapshot has been accepted, it will begin requesting snapshot chunks from peers. Once the snapshot is verified, the node will begin to process blocks in realtime until it catches up with the head of the chain. For more information on state sync, see [Tendermint's documentation](https://docs.tendermint.com/master/spec/p2p/messages/state-sync.html).
+
+To enable state, visit an explorer to get a recent block height and corresponding hash. A node operator can choose any height/hash in the current bonding period, but as the recommended snapshot period is `1000` blocks, it is advised to choose something close to`height - 1000`.
+
+With the block height and hash selected, update the configuration in `~/.gaia/config/config.toml` to set `enable = true`, and populate the `trust_height` and `trust_hash`. Node operators can configure the rpc servers to a preferred provider, but there must be at least two entries. It is important that these are two rpc servers the node operator trusts to verify component parts of the chain state. While not reccommended, uniqueness is not currently enforced, so it is possible to duplicate the same server in the list and still sync successfully.
+
+> **Note**: In the future, the RPC server requirement will be deprecated as state sync is [moved to the p2p layer in Tendermint 0.35](https://github.com/tendermint/tendermint/issues/6491).
+
+```
+#######################################################
+###         State Sync Configuration Options        ###
+#######################################################
+[statesync]
+# State sync rapidly bootstraps a new node by discovering, fetching, and restoring a state machine
+# snapshot from peers instead of fetching and replaying historical blocks. Requires some peers in
+# the network to take and serve state machine snapshots. State sync is not attempted if the node
+# has any local state (LastBlockHeight > 0). The node will have a truncated block history,
+# starting from the height of the snapshot.
+enable = true
+
+# RPC servers (comma-separated) for light client verification of the synced state machine and
+# retrieval of state data for node bootstrapping. Also needs a trusted height and corresponding
+# header hash obtained from a trusted source, and a period during which validators can be trusted.
+#
+# For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
+# weeks) during which they can be financially punished (slashed) for misbehavior.
+rpc_servers = "https://rpc-cosmoshub.keplr.app:443,https://rpc.cosmos.network:443"
+trust_height = 8959784
+trust_hash = "3D8F12EA302AEDA66E80939F7FC785206692F8B6EE6F727F1655F1AFB6A873A5"
+trust_period = "168h0m0s"
+```
+
+Start Gaia to begin state sync. It may take take some time for the node to acquire a snapshot, but the command and output should look similar to the following:
 
 ```bash
-sudo tee /etc/systemd/system/gaiad.service > /dev/null <<EOF  
+$ gaiad start --x-crisis-skip-assert-invariants
+
+...
+
+> INF Discovered new snapshot format=1 hash="0x000..." height=8967000 module=statesync
+
+...
+
+> INF Fetching snapshot chunk chunk=4 format=1 height=8967000 module=statesync total=45
+> INF Applied snapshot chunk to ABCI app chunk=0 format=1 height=8967000 module=statesync total=45
+```
+
+Once state sync successfully completes, the node will begin to process blocks normally. If state sync fails and the node operator encounters the following error:  `State sync failed err="state sync aborted"`, either try restarting `gaiad` or running `gaiad unsafe-reset-all` (make sure to backup any configuration and history before doing this).
+
+### Quicksync
+Quicksync.io offers several  daily snapshots of the Cosmos Hub with varying levels of pruning (`archive` 1.4TB, `default` 540GB, and `pruned` 265GB). For downloads and installation instructions, visit the [Cosmos Quicksync guide](https://quicksync.io/networks/cosmos.html).
+
+
+## Snapshots
+Saving and serving snapshots helps nodes rapidly join the network.
+
+To contribute snapshots to the network, `snapshot-interval` needs to be configured in `~/.gaia/config/app.toml`. The Cosmos Hub recommends setting this value to `1000`. This value must match `pruning-keep-every` in `config.toml`.
+
+In `app.toml`
+```
+###############################################################################
+###                        State Sync Configuration                         ###
+###############################################################################
+
+# State sync snapshots allow other nodes to rapidly join the network without replaying historical
+# blocks, instead downloading and applying a snapshot of the application state at a given height.
+[state-sync]
+
+# snapshot-interval specifies the block interval at which local state sync snapshots are
+# taken (0 to disable). Must be a multiple of pruning-keep-every.
+snapshot-interval = 1000
+
+# snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
+snapshot-keep-recent = 10
+```
+
+It is highly recommended that node operators use the same value for snapshot-interval in order to aid snapshot discovery. Discovery is easier when more nodes are serving the same snapshots.
+
+
+## Hardware
+Running a full archive node can be resource intensive as the full  current `cosmoshub-4` state is over `1.4TB`. For those who wish to run state sync or use quicksync, the following hardware configuration is recommended:
+
+| Node Type     | RAM                   | Storage     |
+| -----------   | --------------------- | ----------- |
+| Validator     | 16GB (32 Recommended) | 500GB-2TB*  |
+| Full/Archive  | 8GB (16 Recommended)  | 2TB         |
+| Default       | 8GB (16 Recommended)  | 1TB         |
+| Pruned        | 8 GB                  | 500GB       |
+
+\* Storage size for validators will depend on level of pruning.
+
+
+## Releases & Upgrades
+**See all [Gaia Releases](https://github.com/cosmos/gaia/releases)**
+
+The most up to date release of Gaia is [`V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). For those that want to use state sync or quicksync to get their node up to speed, starting with the most recent version of Gaia is sufficient.
+
+To sync an archive or full node from scratch, it is important to note that you must start with [`V4.2.1`](https://github.com/cosmos/gaia/releases/tag/v4.2.1) and proceed through two different upgrades Delta at block height `6910000` and Vega at block height `8695000`.
+
+The process is summarized below but make sure to follow the manual upgrade instructions for each release:
+
+**[Delta Instructions](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md#Upgrade-will-take-place-July-12,-2021)**
+Once `V4` reaches the upgrade block height, expect the chain to halt and to see the following message:
+```bash
+ERR UPGRADE "Gravity-DEX" NEEDED at height: 6910000: v5.0.0-4760cf1f1266accec7a107f440d46d9724c6fd08
+```
+
+Make sure to save a backup of `~/.gaia` in case rolling back is necessary.
+
+Install Gaia [`V5.0.0`](https://github.com/cosmos/gaia/releases/tag/v5.0.0) and restart the daemon.
+
+
+**[Vega Instructions](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-vega-upgrade.md)**
+
+Once `V5` reaches the upgrade block height, the chain will halt and display the following message:
+```bash
+ERR UPGRADE "Vega" NEEDED at height: 8695000
+
+```
+
+Again, make sure to backup `~/.gaia`
+
+Install Gaia [`V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0) and restart the daemon.
+
+
+## Cosmovisor
+
+Cosmovisor is a process manager developed to relieve node operators of having to manually intervene every time there is an upgrade. Cosmovisor monitors the governance module for upgrade proposals; it will take care of downloading the new binary, stopping the old one, switching to the new one, and restarting.
+
+For more information on how to run a node via Cosmovisor, check out the [docs](https://github.com/cosmos/cosmos-sdk/blob/master/cosmovisor/README.md).
+
+
+## Running via Background Process
+
+To run the node in a background process with automatic restarts, it's recommended to use a service manager like `systemd`. To set this up run the following:
+
+```bash
+sudo tee /etc/systemd/system/<service name>.service > /dev/null <<EOF  
 [Unit]
 Description=Gaia Daemon
 After=network-online.target
@@ -241,7 +368,7 @@ WantedBy=multi-user.target
 EOF
 ```
 
-If you're using Cosmovisor you want to add
+If using Cosmovisor then make sure to add the following:
 
 ```bash
 Environment="DAEMON_HOME=$HOME/.gaia"
@@ -250,24 +377,25 @@ Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 ```
 
-after the `LimitNOFILE` line and replace `$(which gaiad)` with `$(which cosmovisor)`.
+After the `LimitNOFILE` line and replace `$(which gaiad)` with `$(which cosmovisor)`.
 
-Then setup the daemon
+Run the following to setup the daemon:
 
 ```bash
 sudo -S systemctl daemon-reload
-sudo -S systemctl enable gaiad
+sudo -S systemctl enable <service name>
 ```
 
-We can then start the process and confirm that it is running
+Then start the process and confirm that it's running.
 
 ```bash
-sudo -S systemctl start gaiad
+sudo -S systemctl start <service name>
 
-sudo service gaiad status
+sudo service <service name> status
 ```
 
-## Export State
+
+## Exporting State
 
 Gaia can dump the entire application state into a JSON file. This application state dump is useful for manual analysis and can also be used as the genesis file of a new network.
 
@@ -288,6 +416,7 @@ If you plan to start a new network from the exported state, export with the `--f
 ```bash
 gaiad export --height [height] --for-zero-height > [filename].json
 ```
+
 
 ## Verify Mainnet
 
@@ -315,6 +444,3 @@ invariant broken:
         gaiad tx crisis invariant-broken staking supply
 
 ```
-
-When submitting a invariant-broken transaction, transaction fee tokens are not
-deducted as the blockchain will halt (invariant-broken transactions are free transactions).

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -4,35 +4,39 @@ order: 3
 
 # Join the Cosmos Hub Mainnet
 
-The current Cosmos Hub mainnet`cosmoshub-4`is operating after its most recent [Vega upgrade `V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). This guide includes instructions for joining the mainnet either as an archive/full node or a pruned node. For instructions to join as a validator, please also see the [validator instructions](https://hub.cosmos.network/main/validators/overview.html#).
+The current Cosmos Hub mainnet`cosmoshub-4`is operating after its most recent [Vega upgrade `V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). This guide includes full instructions for joining the mainnet either as an archive/full node or a pruned node.
+<!-- TODO: Link Future Quick Start Guide -->
+For instructions to boostrap a node via Quicksync or State Sync, see the [Quickstart Guide](https://github.com/cosmos/mainnet/blob/306363b874e5dea91d3305788f2d864713aa10e0/README.md)
+
+For instructions to join as a validator, please also see the [Validator Guide](https://hub.cosmos.network/main/validators/overview.html#).
 
 ### Overview
-
-- [Explorers](#Explorers)
-- [Getting Started](#Getting-Started)
-- [General Configuration](#General-Configuration)
-    - [Initialize Chain](#Initialize-Chain)
-    - [Genesis File](#Genesis-File)
-    - [Seeds & Peers](#Seeds-amp-Peers)
-    - [Gas & Fees](#Gas-amp-Fees)
-    - [Pruning of State](#Pruning-of-State)
-    - [REST API](#REST-API)
-    - [GRPC](#GRPC)
-- [Choosing a Sync Mode](#Choosing-a-Sync-Mode)
-    - [Sync from Scratch (Full/Archive Node)](#Sync-from-scratch)
-    - [State Sync](#State-Sync)
-    - [Quicksync](#Quicksync)
-- [Snapshots](#Snapshots)
-- [Hardware Requirements](#Hardware)
-- [Releases](#Releases-amp-Upgrades)
-- [Cosmovisor](#Cosmovisor)
-- [Running via Background Process](#Running-via-Background-Process)
-- [Exporting State](#Exporting-State)
-- [Verify Mainnet](#Verify-Mainnet)
+<!-- DON'T FORGET TO KEEP INDEX UP TO DATE -->
+- [Explorers](#explorers)
+- [Getting Started](#getting-started)
+- [General Configuration](#general-configuration)
+    - [Initialize Chain](#initialize-chain)
+    - [Genesis File](#genesis-file)
+    - [Seeds & Peers](#seeds-amp-peers)
+    - [Gas & Fees](#gas-amp-fees)
+    - [Pruning of State](#pruning-of-state)
+    - [REST API](#rest-api)
+    - [GRPC](#grpc)
+- [Sync Options](#sync-options)
+    - [Blocksync](#blocksync)
+    - [State Sync](#state-sync)
+    - [Quicksync](#quicksync)
+- [Snapshots](#snapshots)
+- [Hardware Requirements](#hardware)
+- [Releases](#releases-amp-upgrades)
+- [Cosmovisor](#cosmovisor)
+- [Running via Background Process](#running-via-background-process)
+- [Exporting State](#exporting-state)
+- [Verify Mainnet](#verify-mainnet)
 
 ### Background
 
-The current Cosmos Hub mainnet `cosmoshub-4` has been performing in place store migration upgrades as of the [Delta Upgrade](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md) July 2021. The most recent upgrade was [Vega](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-vega-upgrade.md) December 2021. This type of upgrade preserves the same chain-id but is otherwise similar to a traditional hub upgrade, meaning historical state is lost after the upgrade takes place (still accessible of course by a v4.2.1 full node). Visit the [migration section](https://github.com/cosmos/gaia/tree/main/docs/migration) of the Hub's docs for more information on previous chain migrations.
+The current Cosmos Hub mainnet `cosmoshub-4`. Visit the [migration section](https://github.com/cosmos/gaia/tree/main/docs/migration) of the Hub's docs for more information on previous chain migrations.
 
 
 ## Explorers
@@ -46,10 +50,9 @@ There are many explorers for the Cosmos Hub. For reference while setting up a no
 
 ## Getting Started
 
-Before syncing a node, make sure the following prerequisites are completed:
+Make sure the following prerequisites are completed:
 - Choose the proper hardware/server configuration. See the [hardware guide](#hardware).
 - Ensure Gaia is properly installed. See the [installation guide](https://hub.cosmos.network/main/getting-started/installation.html) for a walkthrough.
-- Compile the Gaia binary (also in the installation guide). The version of Gaia will depend on [which way the node is synced](#Choosing-a-Sync-Mode). If syncing from scratch checkout version [`v4.2.1`](https://github.com/cosmos/gaia/releases/tag/v4.2.1). If syncing via state sync, checkout the [latest release](https://github.com/cosmos/gaia/releases/tag/v6.0.0). If unsure, see [releases](#Releases-amp-Upgrades) for more information on the appropriate version to build.
 - Follow the [configuration guide](#General-Configuration) to intialize and prepare the node to sync with the network.
 
 
@@ -94,7 +97,7 @@ seeds = "<seed node id 1>@<seed node address 1>:26656,<seed node id 2>@<seed nod
 persistent_peers = "<node id 1>@<node address 1>:26656,<node id 2>@<node address 2>:26656"
 ```
 
-Alternatively, node operators can also download the [Quicksync address book]( https://quicksync.io/addrbook.cosmos.json). Make sure this is moved to `~/.gaia/config/addrbook.json`.
+Node operators can optionally download the [Quicksync address book]( https://quicksync.io/addrbook.cosmos.json). Make sure to move this to `~/.gaia/config/addrbook.json`.
 
 ### Gas & Fees
 
@@ -106,11 +109,11 @@ Transactions on the Cosmos Hub network need to include a transaction fee in orde
 fees = ceil(gas * gasPrices)
 ```
 
-The `gas` is dependent on the transaction. Different transaction require different amount of `gas`. The `gas` amount for a transaction is calculated as it is being processed, but there is a way to estimate it beforehand by using the `auto` value for the `gas` flag. Of course, this only gives an estimate. This estimate is adjustable with the flag `--gas-adjustment` (default `1.0`) to ensure enough `gas` is provided for the transaction.
+`Gas` is the smallest unit or pricing value required to perform a transaction. Different transactions require different amounts of `gas`. The `gas` amount for a transaction is calculated as it is being processed, but it can be estimated beforehand by using the `auto` value for the `gas` flag. The gas estimate can be adjusted with the flag `--gas-adjustment` (default `1.0`) to ensure enough `gas` is provided for the transaction.
 
 The `gasPrice` is the price of each unit of `gas`. Each validator sets a `min-gas-price` value, and will only include transactions that have a `gasPrice` greater than their `min-gas-price`.
 
-The transaction `fees` are the product of `gas` and `gasPrice`. The higher the `gasPrice`/`fees`, the higher the chance that your transaction will get included in a block.
+The transaction `fees` are the product of `gas` and `gasPrice`. The higher the `gasPrice`/`fees`, the higher the chance that a transaction will get included in a block.
 
 **For mainnet, the recommended `gas-prices` is `0.0025uatom`.**
 
@@ -124,6 +127,7 @@ minimum-gas-prices = "0.0025uatom"
 ```
 
 The initial recommended `min-gas-prices` is `0.0025uatom`, but this can be changed later.
+
 
 ### Pruning of State
 
@@ -194,19 +198,54 @@ address = "0.0.0.0:9090"
 ```
 
 
-## Choosing a Sync Mode
+## Sync Options
 
-There are three main ways to sync a node on the Cosmos Hub. The way a node operator will want to sync is partially dependent on the type of node they will operate. This guide will focus on two types of common nodes; archive/full and pruned. For further information on syncing to run a validator node, see the section on [Validators](https://hub.cosmos.network/main/validators/overview.html).
+There are three main ways to sync a node on the Cosmos Hub; Blocksync, State Sync, and Quicksync. See the matrix below for the Hub's recommended setup configuration. This guide will focus on syncing two types of common nodes; full and pruned. For further information on syncing to run a validator node, see the section on [Validators](https://hub.cosmos.network/main/validators/overview.html).
 
-If a node operator wishes to run a full/archive node, it is possible to start from scratch but will take a significant amount of time to catch up. Node operators not concerned with rebuilding original state from the beginning of `cosmoshub-4` can also leverage [Quicksync](#Quicksync)'s available archive history.
+There are two types of concerns when deciding which sync option is right. _Data integrity_ refers to how reliable the data provided by a subset of network participants is. _Historical data_ refers to how robust and inclusive the chain’s history is.
+
+|                           | Low Data Integrity   |   High Data Integrity |
+| -----------------------   | -------------------- | --------------------- |
+| Minimal Historical Data   | Quicksync - Pruned   | State Sync            |
+| Moderate Historical Data  | Quicksync - Default  |                       |
+| Full Historical Data      | Quicksync - Archive  | Blocksync             |
+
+
+
+If a node operator wishes to run a full node, it is possible to start from scratch but will take a significant amount of time to catch up. Node operators not concerned with rebuilding original state from the beginning of `cosmoshub-4` can also leverage [Quicksync](#Quicksync)'s available archive history.
 
 For operators interested in bootstrapping a pruned node, either [Quicksync](#Quicksync) or [State Sync](#State-Sync) would be sufficient.
 
+
+
+
+
 Make sure to consult the [hardware](#Hardware) section for guidance on the best configuration for the type of node operating.
 
-### Sync from scratch
 
-Syncing from scratch is possible by starting the chain from the beginning of `cosmoshub-4` and either manually upgrading the chain or setting up [Cosmovisor](#Cosmovisor) to upgrade automatically. Node operators syncing from scratch will need to navigate two upgrades, Delta and Vega. For more information on performing the manual upgrades, see [Releases & Upgrades](#Releases-amp=-Upgrades).
+
+<!-- #sync options -->
+::::::: tabs :options="{ useUrlFragment: false }"
+
+:::::: tab Blocksync
+### Blocksync
+
+Blocksync is faster than traditional consensus and syncs the chain from genesis by downloading blocks and verifying against the merkle tree of validators. For more information see [Tendermint's Blocksync Docs](https://docs.tendermint.com/master/tendermint-core/block-sync/)
+
+When syncing via Blocksync, node operators will either need to manually upgrade the chain or set up [Cosmovisor](#Cosmovisor) to upgrade automatically.
+
+For more information on performing the manual upgrades, see [Releases & Upgrades](#Releases-amp=-Upgrades).
+
+It is possible to sync from previous versions of the Cosmos Hub. See the matrix below for the correct `gaia` version. See the [mainnet archive](https://github.com/cosmos/mainnet) for historical genesis files.
+
+| Chain Id      | Gaia Version  |
+| -----------   | -------- |
+| `cosmoshub-4` | `v4.2.1` |
+| `cosmoshub-3` | `v2.0.x` |
+| `cosmoshub-2` | `v1.0.x` |
+| `cosmoshub-1` | `v0.0.x` |
+
+##### Getting Started
 
 Start Gaia to begin syncing with the `skip-invariants` flag. For more information on this see [Verify Mainnet](#Verify-Mainnet).
 ```bash
@@ -215,10 +254,12 @@ gaiad start --x-crisis-skip-assert-invariants
 ```
 
 The node will begin rebuilding state until it hits the first upgrade height at block `6910000`. If Cosmovisor is set up then there's nothing else to do besides wait, otherwise the node operator will need to perform the manual upgrade twice.
+::::::
 
+:::::: tab State Sync
 ### State Sync
 
-Enabling state sync can be one of the most efficient ways to bootstrap a node. On startup, the node will ask its peers for available snapshots. Once a snapshot has been accepted, it will begin requesting snapshot chunks from peers. Once the snapshot is verified, the node will begin to process blocks in realtime until it catches up with the head of the chain. For more information on state sync, see [Tendermint's documentation](https://docs.tendermint.com/master/spec/p2p/messages/state-sync.html).
+State Sync is an efficient and fast way to bootstrap a new node, and it works by replaying larger chunks of application state directly rather than replaying individual blocks or consensus rounds. For more information, see [Tendermint's State Sync docs](https://docs.tendermint.com/master/spec/p2p/messages/state-sync.html).
 
 To enable state sync, visit an explorer to get a recent block height and corresponding hash. A node operator can choose any height/hash in the current bonding period, but as the recommended snapshot period is `1000` blocks, it is advised to choose something close to `current height - 1000`.
 
@@ -266,15 +307,23 @@ $ gaiad start --x-crisis-skip-assert-invariants
 ```
 
 Once state sync successfully completes, the node will begin to process blocks normally. If state sync fails and the node operator encounters the following error:  `State sync failed err="state sync aborted"`, either try restarting `gaiad` or running `gaiad unsafe-reset-all` (make sure to backup any configuration and history before doing this).
+::::::
 
+:::::: tab Quicksync
 ### Quicksync
 Quicksync.io offers several  daily snapshots of the Cosmos Hub with varying levels of pruning (`archive` 1.4TB, `default` 540GB, and `pruned` 265GB). For downloads and installation instructions, visit the [Cosmos Quicksync guide](https://quicksync.io/networks/cosmos.html).
+::::::
 
+:::::::
+
+<!-- #end -->
 
 ## Snapshots
-Saving and serving snapshots helps nodes rapidly join the network.
+Saving and serving snapshots helps nodes rapidly join the network. Snapshots are now enabled by default effective `1/20/21`.
 
-To contribute snapshots to the network, `snapshot-interval` needs to be configured in `~/.gaia/config/app.toml`. The Cosmos Hub recommends setting this value to `1000`. This value must match `pruning-keep-every` in `config.toml`.
+While not advised, if a node operator needs to customize this feature, it can be configured in `~/.gaia/config/app.toml`. The Cosmos Hub recommends setting this value to match `pruning-keep-every` in `config.toml`.
+
+> **Note**: It is highly recommended that node operators use the same value for snapshot-interval in order to aid snapshot discovery. Discovery is easier when more nodes are serving the same snapshots.
 
 In `app.toml`
 ```
@@ -293,8 +342,6 @@ snapshot-interval = 1000
 # snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
 snapshot-keep-recent = 10
 ```
-
-It is highly recommended that node operators use the same value for snapshot-interval in order to aid snapshot discovery. Discovery is easier when more nodes are serving the same snapshots.
 
 
 ## Hardware
@@ -402,6 +449,8 @@ sudo service <service name> status
 ## Exporting State
 
 Gaia can dump the entire application state into a JSON file. This application state dump is useful for manual analysis and can also be used as the genesis file of a new network.
+
+> **Note**: The node can't be running while exporting state, otherwise the operator can expect a `resource temporarily unavailable` error.
 
 Export state with:
 

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -4,7 +4,11 @@ order: 3
 
 # Join the Cosmos Hub Mainnet
 
-The current Cosmos Hub mainnet`cosmoshub-4`is operating after its most recent [Vega upgrade `V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). This guide includes full instructions for joining the mainnet either as an archive/full node or a pruned node.
+The current Cosmos Hub mainnet, `cosmoshub-4`, has been performing in place store migration upgrades as of the [Delta Upgrade](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md) July 2021. The most recent upgrade was [Vega](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-vega-upgrade.md) December 2021. This type of upgrade preserves the same chain-id but state before the upgrade height is only accessible by corresponding versions of the binary (ie. queries of state between height `6910000` and `8695000` should use `gaia v5.0.x` (Delta) but after `86950000` should use `gaia v6.0.x` (Vega) to guarantee correctly encoded responses). Visit the [migration section](https://github.com/cosmos/gaia/tree/main/docs/migration) of the Hub's docs for more information on previous chain migrations.
+
+**This guide includes full instructions for joining the mainnet either as an archive/full node or a pruned node.**
+
+
 <!-- TODO: Link Future Quick Start Guide -->
 For instructions to boostrap a node via Quicksync or State Sync, see the [Quickstart Guide](https://github.com/cosmos/mainnet/blob/306363b874e5dea91d3305788f2d864713aa10e0/README.md)
 
@@ -46,6 +50,7 @@ There are many explorers for the Cosmos Hub. For reference while setting up a no
 - [Mintscan](https://www.mintscan.io/cosmos)
 - [Big Dipper](https://cosmos.bigdipper.live/)
 - [Hubble](https://hubble.figment.io/cosmos/chains/cosmoshub-4)
+- [Stake ID](https://cosmos.stake.id/)
 
 
 ## Getting Started
@@ -350,9 +355,8 @@ Running a full archive node can be resource intensive as the full  current `cosm
 | Node Type     | RAM                   | Storage     |
 | -----------   | --------------------- | ----------- |
 | Validator     | 16GB (32 Recommended) | 500GB-2TB*  |
-| Full/Archive  | 8GB (16 Recommended)  | 2TB         |
+| Full          | 8GB (16 Recommended)  | 2TB         |
 | Default       | 8GB (16 Recommended)  | 1TB         |
-| Pruned        | 8 GB                  | 500GB       |
 
 \* Storage size for validators will depend on level of pruning.
 

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -279,7 +279,7 @@ gaiad start --x-crisis-skip-assert-invariants
 The node will begin rebuilding state until it hits the first upgrade height at block `6910000`. If Cosmovisor is set up then there's nothing else to do besides wait, otherwise the node operator will need to perform the manual upgrade twice.
 ::::::
 
-:::::: tab State Sync
+:::::: tab "State Sync"
 ### State Sync
 
 State Sync is an efficient and fast way to bootstrap a new node, and it works by replaying larger chunks of application state directly rather than replaying individual blocks or consensus rounds. For more information, see [Tendermint's State Sync docs](https://docs.tendermint.com/master/spec/p2p/messages/state-sync.html).


### PR DESCRIPTION
Current `Joining Mainnet` Hub Docs are out of date and often leave newcomers confused as to the best way to bootstrap a node. Changes include a more robust section on the types of syncing available , and how to configure/implement each. A preview can be viewed at [here](https://hackmd.io/vqbYbFzDST2gCKlcbbZ71Q#Join-the-Cosmos-Hub-Mainnet)