### PR TITLE
Theta update

### DIFF
--- a/docs/roadmap/cosmos-hub-roadmap-2.0.md
+++ b/docs/roadmap/cosmos-hub-roadmap-2.0.md
@@ -39,7 +39,7 @@ The upgrades aim to add features such as liquidity, economic security, usability
 - IBC 3.0
   - Interchain accounts
     - A requirement in order to manage accounts across multiple blockchains
-    - Aims to provide locking/unlocking mechanisms across IBC-enabled blockchains
+    - Provides locking/unlocking mechanisms across IBC-enabled blockchains
     - Would allow custody providers to service any IBC connected blockchain through a common interface on the Hub.
 
 ## v8-Rho Upgrade (expected Q2 2022)

--- a/docs/roadmap/cosmos-hub-roadmap-2.0.md
+++ b/docs/roadmap/cosmos-hub-roadmap-2.0.md
@@ -40,7 +40,7 @@ The upgrades aim to add features such as liquidity, economic security, usability
   - Interchain accounts
     - A requirement in order to manage accounts across multiple blockchains
     - Provides locking/unlocking mechanisms across IBC-enabled blockchains
-    - Would allow custody providers to service any IBC connected blockchain through a common interface on the Hub.
+    - Will allow custody providers to service any IBC connected blockchain through a common interface on the Hub.
 
 ## v8-Rho Upgrade (expected Q2 2022)
 - Gaia v8.0.x

--- a/docs/roadmap/cosmos-hub-roadmap-2.0.md
+++ b/docs/roadmap/cosmos-hub-roadmap-2.0.md
@@ -37,10 +37,13 @@ The upgrades aim to add features such as liquidity, economic security, usability
 - Cosmos SDK v0.45
   - Minimal update with small fixes
 - IBC 3.0
-  - Interchain accounts
-    - A requirement in order to manage accounts across multiple blockchains
-    - Provides locking/unlocking mechanisms across IBC-enabled blockchains
-    - Will allow custody providers to service any IBC connected blockchain through a common interface on the Hub.
+  - Interchain Account Module
+    - Allows the creation of accounts on a "Host" blockchain which are controlled by an authentication module on a "Controller" blockchain.
+    - Arbitrary messages are able to be submitted from the "Controller" blockchain to the "Host" blockchain to be executed on behalf of the Interchain Account.
+    - Uses ordered IBC channels, one per account.
+- Interchain Account Message Auhothorization Module
+    - Authentication module that authorizes any Account to create an Interchain Account on any IBC connected "Host" blockchain that has the Interchain Account IBC module.
+    - Accounts can be private key controlled users, and eventually the Gov Module and any Groups Module.
 
 ## v8-Rho Upgrade (expected Q2 2022)
 - Gaia v8.0.x
@@ -62,8 +65,6 @@ The upgrades aim to add features such as liquidity, economic security, usability
 - Governance permissioned CosmWASM instance on the hub
 - Budget Module
   - Inflation funding directed to arbitrary module and account addresses
-- Farming Module
-  - Rewards for locked tokens, especially LP tokens for different trading pair pools
 
 ## v9-Lambda Upgrade (expected Q3 2022)
 - Gaia v9.0.x

--- a/docs/roadmap/cosmos-hub-roadmap-2.0.md
+++ b/docs/roadmap/cosmos-hub-roadmap-2.0.md
@@ -7,14 +7,14 @@ This roadmap gives a one-year guideline in which stakeholders can anticipate upd
 The upgrades aim to add features such as liquidity, economic security, usability, and participation. To highlight our focus on DeFi, we have chosen to use the [Greeks from Finance](https://en.wikipedia.org/wiki/Greeks_(finance)) in naming upcoming upgrades.
 
 ## Delta Upgrade (Completed July 12, 2021)
-
+- Gaia v5.0.x
 - Gravity DEX:
   - A scalable AMM model for token swaps
   - Drives liquidity for tokens on the Cosmos Hub
   - Delivers price consistency and order execution
 
 ## Vega Upgrade (Completed December 14, 2021)
-
+ - Gaia v6.0.x
  - Cosmos SDK v0.44
    - Fee grant module:
       - Allows paying fees on behalf of another account
@@ -32,9 +32,19 @@ The upgrades aim to add features such as liquidity, economic security, usability
   - Transfer ATOM, ETH, ERC-20, and other Cosmos tokens between Ethereum and the Gravity Bridge Chain and by extension all IBC connected chains.
   - Fee and reward model hosted across Cosmos and Ethereum
 
-## Theta Upgrade (expected Q1 2022)
-
+## v7-Theta Upgrade (expected Q1 2022)
+- Gaia v7.0.x
 - Cosmos SDK v0.45
+  - Minimal update with small fixes
+- IBC 3.0
+  - Interchain accounts
+    - A requirement in order to manage accounts across multiple blockchains
+    - Aims to provide locking/unlocking mechanisms across IBC-enabled blockchains
+    - Would allow custody providers to service any IBC connected blockchain through a common interface on the Hub.
+
+## v8-Rho Upgrade (expected Q2 2022)
+- Gaia v8.0.x
+- Cosmos SDK v0.46
   - Groups module:
     - Enables higher-level multisig permissioned accounts, e.g., weight-based voting policies
   - Meta-Transactions
@@ -46,22 +56,17 @@ The upgrades aim to add features such as liquidity, economic security, usability
   - Enable simple management of NFT identifiers, their owners, and associated data, such as URIs, content, and provenance
   - An extensible base module for extensions including collectibles, custody, provenance, and marketplaces
 - Tendermint v0.35
-- Interchain accounts
-  - A requirement in order to manage accounts across multiple blockchains
-  - Aims to provide locking/unlocking mechanisms across IBC-enabled blockchains
-  - Would allow custody providers to service any IBC connected blockchain through a common interface on the Hub.
 - Liquid Staking
   - Frees secure and low-risk delegations for use in other parts of the Cosmos ecosystem
   - Features include enabling transfer of rewards and voting rights
-- Items still being discussed:
-  - Governance permissioned CosmWASM instance on the hub
-  - Budget Module
-    - Inflation funding directed to arbitrary module and account addresses
-  - Farming Module
-    - Rewards for locked tokens, especially LP tokens for different trading pair pools
+- Governance permissioned CosmWASM instance on the hub
+- Budget Module
+  - Inflation funding directed to arbitrary module and account addresses
+- Farming Module
+  - Rewards for locked tokens, especially LP tokens for different trading pair pools
 
-## Rho Upgrade (expected Q2 2022)
-
+## v9-Lambda Upgrade (expected Q3 2022)
+- Gaia v9.0.x
 - Interchain Security v1 - Required Participation of Provider Chain Validators
   - The Cosmos solution to shared security that uses IBC Cross Chain Validation (CCV) to relay validator set composition from a Provider Chain (Cosmos Hub) to a Consumer Chain. This validator set is in charge of producing blocks on both networks using separate nodes. Misbehavior on the Consumer Chain results in slashing Provider Chain staking tokens (ATOM).
   - Allows independent modules like Gravity DEX or Bridge to live on separate chains with their own development cycles.
@@ -73,35 +78,25 @@ The upgrades aim to add features such as liquidity, economic security, usability
   - Account registry
   - Bech32 registry
 
-
-## Lambda Upgrade (expected Q3 2022)
-
+## v10-Epsilon (expected Q4 2022)
+- Gaia v10.0.x
 - Interchain Security v2 - Opt-In Participation of Provider Chain Validators
   - Where Provider Chain validators have the ability to opt-in to block production for various Consumer Chains.
-- Cosmos SDK v0.46
+- Cosmos SDK v0.47
   - Sparse Merkle Tree (SMT)
     - Various storage and performance optimizations 
   - Postgres indexing
   - Protobuf v2
-- Token Issuance
-  - Enables creation of tokens directly on the Hub
-  - Aims to provide ERC20 capabilities
-- Gravity DEX v2
-  - Order matching
 
-## Epsilon (expected Q4 2022)
-
+## v11-Gamma (expected Q1 2023)
+- Gaia v11.0.x
 - Interchain Security v3 - Layered Security
   - Where Consumer Chains combine their own staking token validator set with Provider Chain validator set.
 
-## Future Upgrades
-
-- Cross-chain bridges (non-IBC)
-- Atomic Exchange
-- Decentralized identifiers (DID)
-- Privacy
-- Virtual machines
-- Smart contract languages
-- Zero knowledge and optimistic rollups
+## Future Considerations
+The Cosmos Hub is a decentralized network with many diverse contributors. As such there is no one authority of what is or can be part of the Cosmos Network. The Cosmos Hub team at Interchain does it's best to maintain the Gaia repository, which is the primary codebase that operates the Cosmos Network. The Interchain Foundation is one of the sources of funding for engineering work that may make its way onto the Cosmos Hub. We do our best to participate in ongoing conversations about the mission, vision and purpose of the Cosmos Hub, so that we can best support work to enabling it via funding, engineering, coordination and communication. Some of the topics which have been discussed by contributors inside and outside of Interchain are listed below, although have not been developed to the point of being included in the roadmap:
+* Privacy
+* Smart Contracts
+* Rollups
 
 The Cosmos Hub Roadmap is maintained by the Interchain Cosmos Hub team as a living document, and is updated in collaboration with key stakeholders from the multi-entity Cosmos community. 


### PR DESCRIPTION
based on the timelines of expected upstream dependencies, the theta upgrade has been reduced to focus on interchain accounts within the next release of IBC and the small release of v0.45 of the Cosmos SDK.