### PR TITLE
Update and rename module-readiness.md to feature-readiness.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-readiness.md
+++ b/.github/ISSUE_TEMPLATE/feature-readiness.md
@@ -29,7 +29,6 @@ Continuity
 Integrations
   - [ ] Gaia integration
   - [ ] Integration partner:
-  - [ ] [IBC Readiness](https://github.com/cosmos/stargate-launch/blob/master/ibc_readiness_matrix.md)
   - [ ] Downstream user impact report
   - [ ] Upstream partner impact report
   - [ ] Inter-module dependence, e.g., pegs  


### PR DESCRIPTION
rename to `feature-readiness.md`

doesn't make sense to include IBC readiness, the link doesn't make sense.