### PR TITLE
R4R: Update reproducible build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ build-reproducible: go.sum
         --env VERSION=$(VERSION) \
         --env COMMIT=$(COMMIT) \
         --env LEDGER_ENABLED=$(LEDGER_ENABLED) \
-        --name latest-build cosmossdk/rbuilder:latest
+        --name latest-build tendermintdev/rbuilder:latest
 	$(DOCKER) cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
 
 build-linux: go.sum

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,6 +76,8 @@ these artifacts should be included in the release.
 make distclean build-reproducible
 ```
 
+This runs the docker image [tendermintdev/rbuilder](https://hub.docker.com/r/tendermintdev/rbuilder) with a copy of the docker file being used available at [github.com/tendermint/images/master/rbuilder](https://github.com/tendermint/images/tree/master/rbuilder).
+
 Then use the following release text template:
 
 ```markdown

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,7 +76,7 @@ these artifacts should be included in the release.
 make distclean build-reproducible
 ```
 
-This runs the docker image [tendermintdev/rbuilder](https://hub.docker.com/r/tendermintdev/rbuilder) with a copy of the docker file being used available at [github.com/tendermint/images/master/rbuilder](https://github.com/tendermint/images/tree/master/rbuilder).
+This runs the docker image [tendermintdev/rbuilder](https://hub.docker.com/r/tendermintdev/rbuilder) with a copy of the [rbuilder](https://github.com/tendermint/images/tree/master/rbuilder) docker file.
 
 Then use the following release text template:
 

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -292,7 +292,7 @@ The node will begin rebuilding state until it hits the first upgrade height at b
 :::::: tab "State Sync"
 ### State Sync
 
-State Sync is an efficient and fast way to bootstrap a new node, and it works by replaying larger chunks of application state directly rather than replaying individual blocks or consensus rounds. For more information, see [Tendermint's State Sync docs](https://docs.tendermint.com/master/spec/p2p/messages/state-sync.html).
+State Sync is an efficient and fast way to bootstrap a new node, and it works by replaying larger chunks of application state directly rather than replaying individual blocks or consensus rounds. For more information, see [Tendermint's State Sync docs](https://github.com/tendermint/tendermint/blob/master/spec/p2p/messages/state-sync.md).
 
 To enable state sync, visit an explorer to get a recent block height and corresponding hash. A node operator can choose any height/hash in the current bonding period, but as the recommended snapshot period is `1000` blocks, it is advised to choose something close to `current height - 1000`.
 


### PR DESCRIPTION
to use latest reproducible build docker image from https://github.com/tendermint/images which is published on the tendermintdev dockerhub account