### PR TITLE
build: bump liquidity to v1.4.6 from v1.4.4(unusable)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.44.6
 	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/gorilla/mux v1.8.0
-	github.com/gravity-devs/liquidity v1.4.4
+	github.com/gravity-devs/liquidity v1.4.6
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -476,8 +476,8 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
-github.com/gravity-devs/liquidity v1.4.4 h1:AlBxXlNoRekptEopulnZsA4HxjUM46rdJLRUSjpHHow=
-github.com/gravity-devs/liquidity v1.4.4/go.mod h1:rSS0iVr8IJ/5Q/Sw5S7Iy3WRMWt+JgQR4ZvPrHCoOww=
+github.com/gravity-devs/liquidity v1.4.6 h1:JIshxDtZG7mmqF/m9nj5HBj58md97J6IPFUdHU5cWhU=
+github.com/gravity-devs/liquidity v1.4.6/go.mod h1:RcE8hMHhY+0bnKVEShiLi+zbboAxNRKTtPgleeJjM5I=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.1/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=


### PR DESCRIPTION
closes: #1307 

Since liquidity [v1.4.4](https://github.com/Gravity-Devs/liquidity/releases/tag/v1.4.4) contain state-breaking changes with patch release,
so revert back to [v1.4.2](https://github.com/Gravity-Devs/liquidity/releases/tag/v1.4.2) and bump cosmos-sdk to v0.44.6 on [v1.4.6](https://github.com/Gravity-Devs/liquidity/releases/tag/v1.4.6)

changelog of liquidity [v1.4.6](https://github.com/Gravity-Devs/liquidity/releases/tag/v1.4.6) from [v1.4.2](https://github.com/Gravity-Devs/liquidity/releases/tag/v1.4.2)
- build: bump cosmos-sdk to v0.44.6 in https://github.com/Gravity-Devs/liquidity/pull/13


https://github.com/Gravity-Devs/liquidity/compare/v1.4.2...v1.4.6
https://github.com/Gravity-Devs/liquidity/compare/v1.4.4...v1.4.6
changelog already added on https://github.com/cosmos/gaia/pull/1275
