### PR TITLE
Update docs with v6.0.4 release

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -93,7 +93,7 @@ You should see something similar to the following:
 ```bash
 name: gaia
 server_name: gaiad
-version: v6.0.0
+version: v6.0.4
 commit: 07f9892a927f451ae204d0c9d1a5601d8fc232a5
 build_tags: netgo,ledger
 go: go version go1.15 linux/amd64

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -24,7 +24,7 @@ For reference, the list of `rpc_servers` and `persistent` peers can be found in 
 ```bash
 # Build gaiad binary and initialize chain
 cd $HOME
-git clone -b v6.0.0 https://github.com/cosmos/gaia
+git clone -b v6.0.4 https://github.com/cosmos/gaia
 cd gaiad
 make install
 gaiad init <custom moniker>

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -270,7 +270,7 @@ It is possible to sync from previous versions of the Cosmos Hub. See the matrix 
 | Stargate            | 18/02/21    | 5,200,791 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.3)          | [v0.40.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.40.1)    | [v4.0.x](https://github.com/cosmos/gaia/releases/tag/v4.0.6)                   | _Included in Cosmos SDK_ |
 | Security Hard Fork  | ?             | ?         | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.8)          | [v0.41.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.41.4)    | [v4.2.x](https://github.com/cosmos/gaia/releases/tag/v4.2.1)                   | _Included in Cosmos SDK_ |
 | Delta (Gravity DEX) | 13/07/21    | 6,910,000 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.13)          | [v0.42.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.10)    | [v5.0.x](https://github.com/cosmos/gaia/releases/tag/v5.0.8)                   | _Included in Cosmos SDK_ |
-| Vega                | 13/12/21    | 8,695,000 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.14)          | [v0.44.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.5)    | [v6.0.x](https://github.com/cosmos/gaia/releases/tag/v6.0.0)                   | [v2.0.x](https://github.com/cosmos/ibc-go/releases/tag/v2.0.3)                   |
+| Vega                | 13/12/21    | 8,695,000 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.14)          | [v0.44.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.5)    | [v6.0.x](https://github.com/cosmos/gaia/releases/tag/v6.0.4)                   | [v2.0.x](https://github.com/cosmos/ibc-go/releases/tag/v2.0.3)                   |
 
 
 
@@ -378,7 +378,7 @@ snapshot-keep-recent = 10
 ## Releases & Upgrades
 **See all [Gaia Releases](https://github.com/cosmos/gaia/releases)**
 
-The most up to date release of Gaia is [`V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). For those that want to use state sync or quicksync to get their node up to speed, starting with the most recent version of Gaia is sufficient.
+The most up to date release of Gaia is [`V6.0.4`](https://github.com/cosmos/gaia/releases/tag/v6.0.4). For those that want to use state sync or quicksync to get their node up to speed, starting with the most recent version of Gaia is sufficient.
 
 To sync an archive or full node from scratch, it is important to note that you must start with [`V4.2.1`](https://github.com/cosmos/gaia/releases/tag/v4.2.1) and proceed through two different upgrades Delta at block height `6910000` and Vega at block height `8695000`.
 
@@ -405,7 +405,7 @@ ERR UPGRADE "Vega" NEEDED at height: 8695000
 
 Again, make sure to backup `~/.gaia`
 
-Install Gaia [`V6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0) and restart the daemon.
+Install Gaia [`V6.0.4`](https://github.com/cosmos/gaia/releases/tag/v6.0.4) and restart the daemon.
 
 
 ## Cosmovisor

--- a/docs/migration/cosmoshub-4-vega-upgrade.md
+++ b/docs/migration/cosmoshub-4-vega-upgrade.md
@@ -16,11 +16,11 @@ TOC:
     - [Backups](#backups)
     - [Testing](#testing)
     - [Current runtime, cosmoshub-4 (pre-Vega upgrade) is running Gaia v5.0.0](#current-runtime-cosmoshub-4-pre-vega-upgrade-is-running-gaia-v500)
-    - [Target runtime, cosmoshub-4 (post-Vega upgrade) will run Gaia v6.0.0](#target-runtime-cosmoshub-4-post-vega-upgrade-will-run-gaia-v600)
+    - [Target runtime, cosmoshub-4 (post-Vega upgrade) will run Gaia v6.0.4](#target-runtime-cosmoshub-4-post-vega-upgrade-will-run-gaia-v604)
 - [Vega upgrade steps](#vega-upgrade-steps)
     - [Method I: manual upgrade](#method-i-manual-upgrade)
-    -  - [Method II: upgrade using Cosmovisor by manually preparing the Gaia v6.0.0 binary](#method-ii-upgrade-using-cosmovisor-by-manually-preparing-the-gaia-v600-binary)
-  - [Method III: upgrade using Cosmovisor by auto-downloading the Gaia v6.0.0 binary (not recommended!)](#method-iii-upgrade-using-cosmovisor-by-auto-downloading-the-gaia-v600-binary-not-recommended)
+    -  - [Method II: upgrade using Cosmovisor by manually preparing the Gaia v6.0.4 binary](#method-ii-upgrade-using-cosmovisor-by-manually-preparing-the-gaia-v604-binary)
+  - [Method III: upgrade using Cosmovisor by auto-downloading the Gaia v6.0.4 binary (not recommended!)](#method-iii-upgrade-using-cosmovisor-by-auto-downloading-the-gaia-v604-binary-not-recommended)
 - [Upgrade duration](#upgrade-duration)
 - [Rollback plan](#rollback-plan)
 - [Communications](#communications)
@@ -70,9 +70,9 @@ For those validator and full node operators that are interested in ensuring prep
 
 The Cosmos Hub mainnet network, `cosmoshub-4`, is currently running [Gaia v5.0.0](https://github.com/cosmos/gaia/releases/tag/v5.0.0). We anticipate that operators who are running on v5.0.x, will be able to upgrade successfully; however, this is untested and it is up to operators to ensure that their systems are capable of performing the upgrade.
 
-### Target runtime, cosmoshub-4 (post-Vega upgrade) will run Gaia v6.0.0
+### Target runtime, cosmoshub-4 (post-Vega upgrade) will run Gaia v6.0.4
 
-The Comsos Hub mainnet network, `cosmoshub-4`, will run [Gaia v6.0.0](https://github.com/cosmos/gaia/releases/tag/v6.0.0). Operators _MUST_ use this version post-upgrade to remain connected to the network.
+The Comsos Hub mainnet network, `cosmoshub-4`, will run [Gaia v6.0.4](https://github.com/cosmos/gaia/releases/tag/v6.0.4). Operators _MUST_ use this version post-upgrade to remain connected to the network.
 
 ## Vega upgrade steps
 There are 2 major ways to upgrade a node:
@@ -80,7 +80,7 @@ There are 2 major ways to upgrade a node:
 - Upgrade using [Cosmovisor](https://github.com/cosmos/cosmos-sdk/tree/master/cosmovisor)
   - Either by manually preparing the new binary
   - Or by using the auto-download functionality (this is not yet recommended)
-    
+
 If you prefer to use Cosmovisor to upgrade, some preparation work is needed before upgrade.
 
 ### Method I: manual upgrade
@@ -90,11 +90,11 @@ ERR UPGRADE "Vega" NEEDED at height: 8695000
 
 panic: UPGRADE "Vega" NEEDED at height: 8695000
 ```
-Stop the node, and install Gaia v6.0.0 and re-start by `gaiad start`.
+Stop the node, and install Gaia v6.0.4 and re-start by `gaiad start`.
 
 It may take 20 min to a few hours until validators with a total sum voting power > 2/3 to complete their nodes upgrades. After that, the chain can continue to produce blocks.
 
-### Method II: upgrade using Cosmovisor by manually preparing the Gaia v6.0.0 binary
+### Method II: upgrade using Cosmovisor by manually preparing the Gaia v6.0.4 binary
 #### Preparation
 
 Install the latest version of Cosmovisor:
@@ -109,7 +109,7 @@ create a Cosmovisor folder inside `$GAIA_HOME` and move Gaia v5.0.0 into ` $GAIA
 mkdir -p $GAIA_HOME/cosmovisor/genesis/bin
 cp $(which gaiad) $GAIA_HOME/cosmovisor/genesis/bin
 ````
-build Gaia v6.0.0, and move gaiad v6.0.0 to `$GAIA_HOME/cosmovisor/upgrades/Vega/bin`
+build Gaia v6.0.4, and move gaiad v6.0.4 to `$GAIA_HOME/cosmovisor/upgrades/Vega/bin`
 
 ```shell
 mkdir -p  $GAIA_HOME/cosmovisor/upgrades/Vega/bin
@@ -125,7 +125,7 @@ Then you should get the following structure:
 └── upgrades
 └── Vega
 └── bin
-    └── gaiad  #v6.0.0
+    └── gaiad  #v6.0.4
 ```
 Export the environmental variables:
 ```shell
@@ -135,21 +135,21 @@ export DAEMON_HOME= $GAIA_HOME
 export DAEMON_RESTART_AFTER_UPGRADE=true
 ```
 
-Start the node: 
+Start the node:
 ```shell
 cosmovisor start --x-crisis-skip-assert-invariants
 ```
 Skipping the invariant checks is strongly encouraged since it decreases the upgrade time significantly and since there are some other improvements coming to the crisis module in the next release of the Cosmos SDK.
- 
+
 #### Expected ugprade result
-When the upgrade block height is reached, you can find the following information in the log: 
+When the upgrade block height is reached, you can find the following information in the log:
 ```shell
 ERR UPGRADE "Vega" NEEDED at height: 8695000: upgrade to Vega and applying upgrade "Vega" at height:8695000.
 ```
  This may take 20 min to a few hours.
  After this, the chain will continue to produce blocks when validators with a total sum voting power > 2/3 complete their nodes upgrades.
 
-### Method III: upgrade using Cosmovisor by auto-downloading the Gaia v6.0.0 binary (not recommended!)
+### Method III: upgrade using Cosmovisor by auto-downloading the Gaia v6.0.4 binary (not recommended!)
 #### Preparation
 Install Cosmovisor v0.1
 ```shell
@@ -185,11 +185,11 @@ cosmovisor start --x-crisis-skip-assert-invariants
 Skipping the invariant checks is strongly encouraged since it decreases the upgrade time significantly and since there are some other improvements coming to the crisis module in the next release of the Cosmos SDK.
 
 #### Expected result
-When the upgrade block height is reached, you can find the following information in the log: 
+When the upgrade block height is reached, you can find the following information in the log:
 ```shell
 ERR UPGRADE "Vega" NEEDED at height: 8695000: upgrade to Vega and applying upgrade "Vega" at height:8695000
 ```
-Then the Cosmovisor will create `$GAIA_HOME/cosmovisor/upgrades/Vega/bin` and download Gaia v6.0.0 binary to this folder according to links in the ` --info` field of the upgrade proposal 59.
+Then the Cosmovisor will create `$GAIA_HOME/cosmovisor/upgrades/Vega/bin` and download Gaia v6.0.4 binary to this folder according to links in the ` --info` field of the upgrade proposal 59.
 This may take 20 min to a few hours, afterwards, the chain will continue to produce blocks once validators with a total sum voting power > 2/3 complete their nodes upgrades.
 
 *Please Note:*

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -20,9 +20,4 @@ For current roadmap, check out the Cosmos 2.0 [Roadmap](./cosmos-hub-roadmap-2.0
 | Stargate            | 18/02/21    | 5,200,791 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.3)          | [v0.40.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.40.1)    | [v4.0.x](https://github.com/cosmos/gaia/releases/tag/v4.0.6)                   | _Included in Cosmos SDK_ |
 | Security Hard Fork  | ?             | ?         | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.8)          | [v0.41.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.41.4)    | [v4.2.x](https://github.com/cosmos/gaia/releases/tag/v4.2.1)                   | _Included in Cosmos SDK_ |
 | Delta (Gravity DEX) | 13/07/21    | 6,910,000 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.13)          | [v0.42.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.10)    | [v5.0.x](https://github.com/cosmos/gaia/releases/tag/v5.0.8)                   | _Included in Cosmos SDK_ |
-| Vega                | 13/12/21    | 8,695,000 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.14)          | [v0.44.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.5)    | [v6.0.x](https://github.com/cosmos/gaia/releases/tag/v6.0.0)                   | [v2.0.x](https://github.com/cosmos/ibc-go/releases/tag/v2.0.3)                   |
-
-
-
-
-
+| Vega                | 13/12/21    | 8,695,000 | `cosmoshub-4` | [v0.34.x](https://github.com/tendermint/tendermint/releases/tag/v0.34.14)          | [v0.44.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.5)    | [v6.0.x](https://github.com/cosmos/gaia/releases/tag/v6.0.4)                   | [v2.0.x](https://github.com/cosmos/ibc-go/releases/tag/v2.0.3)                   |


### PR DESCRIPTION
This PR includes docs updates pointing to the latest version of gaia v6.0.x where necessary. 