### PR TITLE
Update contrib/statesync.bash Bash script

### DIFF
--- a/contrib/statesync.bash
+++ b/contrib/statesync.bash
@@ -2,38 +2,43 @@
 # microtick and bitcanna contributed significantly here.
 set -uxe
 
-# set environment variables
+# Set Golang environment variables.
 export GOPATH=~/go
 export PATH=$PATH:~/go/bin
 
-
-# Install Gaia
+# Install Gaia.
 make install
 
-# MAKE HOME FOLDER AND GET GENESIS
+# Initialize chain.
 gaiad init test 
-wget -O ~/.gaia/config/genesis.json https://cloudflare-ipfs.com/ipfs/Qmc54DreioPpPDUdJW6bBTYUKepmcPsscfqsfFcFmTaVig
 
+# Prepare genesis file for cosmoshub-4.
+wget https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz
+gzip -d genesis.cosmoshub-4.json.gz
+mv genesis.cosmoshub-4.json $HOME/.gaia/config/genesis.json
+
+# Set minimum gas price.
+sed -i'' 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uatom"/' $HOME/.gaia/config/app.toml
+
+# Get "trust_hash" and "trust_height".
 INTERVAL=1000
-
-# GET TRUST HASH AND TRUST HEIGHT
-
-LATEST_HEIGHT=$(curl -s https://cosmoshub-4.technofractal.com/block | jq -r .result.block.header.height);
+LATEST_HEIGHT=$(curl -s https://rpc.cosmos.network/block | jq -r .result.block.header.height)
 BLOCK_HEIGHT=$(($LATEST_HEIGHT-$INTERVAL)) 
-TRUST_HASH=$(curl -s "https://cosmoshub-4.technofractal.com/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)
+TRUST_HASH=$(curl -s "https://rpc.cosmos.network/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)
 
+# Print out block and transaction hash from which to sync state.
+echo "trust_height: $BLOCK_HEIGHT"
+echo "trust_hash: $TRUST_HASH"
 
-# TELL USER WHAT WE ARE DOING
-echo "TRUST HEIGHT: $BLOCK_HEIGHT"
-echo "TRUST HASH: $TRUST_HASH"
-
-
-# export state sync vars
+# Export state sync variables.
 export GAIAD_STATESYNC_ENABLE=true
 export GAIAD_P2P_MAX_NUM_OUTBOUND_PEERS=200
-export GAIAD_STATESYNC_RPC_SERVERS="https://cosmoshub.validator.network:443,https://cosmoshub-4.technofractal.com:443"
+export GAIAD_STATESYNC_RPC_SERVERS="https://rpc.cosmos.network:443,https://rpc.cosmos.network:443"
 export GAIAD_STATESYNC_TRUST_HEIGHT=$BLOCK_HEIGHT
 export GAIAD_STATESYNC_TRUST_HASH=$TRUST_HASH
-export GAIAD_P2P_SEEDS="bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656,366ac852255c3ac8de17e11ae9ec814b8c68bddb@51.15.94.196:26656"
 
+# Fetch and set list of seeds from chain registry.
+export GAIAD_P2P_SEEDS=$(curl -s https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json | jq -r '[foreach .peers.seeds[] as $item (""; "\($item.id)@\($item.address)")] | join(",")')
+
+# Start chain.
 gaiad start --x-crisis-skip-assert-invariants

--- a/contrib/statesync.bash
+++ b/contrib/statesync.bash
@@ -10,12 +10,7 @@ export PATH=$PATH:~/go/bin
 make install
 
 # Initialize chain.
-gaiad init test 
-
-# Prepare genesis file for cosmoshub-4.
-wget https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz
-gzip -d genesis.cosmoshub-4.json.gz
-mv genesis.cosmoshub-4.json $HOME/.gaia/config/genesis.json
+gaiad init test --chain-id cosmoshub-4
 
 # Set minimum gas price.
 sed -i'' 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uatom"/' $HOME/.gaia/config/app.toml


### PR DESCRIPTION
The `contrib/statesync.bash` Bash script contained outdated RPC endpoints and seeds. The current PR fixes this, while also improving its maintainability by:

1. Fetching genesis from https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz, as per documentation
2. Fetching seeds by parsing https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json via `jq`