### PR TITLE
feat: bypass min fee check for IBC relayer txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,15 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 
 ## [Unreleased]
+
+* (ante-handler) [\#1343](https://github.com/cosmos/gaia/pull/1343) Bypass validator min fee checks during CheckTx for specific IBC transactions.
 * (gaia) Bump [Liquidity](https://github.com/gravity-devs/liquidity) module to [v1.4.6](https://github.com/Gravity-Devs/liquidity/releases/tag/v1.4.6).
 * (gaia) Bump [IBC](https://github.com/cosmos/ibc-go) module to [2.0.3](https://github.com/cosmos/ibc-go/releases/tag/v2.0.3).
 * (gaia) [#1230](https://github.com/cosmos/gaia/pull/1230) Fix: update gRPC Web Configuration in `contrib/testnets/test_platform`.
 * (gaia) [#1135](https://github.com/cosmos/gaia/pull/1135) Fix rocksdb build tag usage.
 * (gaia) [#1160](https://github.com/cosmos/gaia/pull/1160) Improvement: update state sync configs.
 * (gaia) [#1208](https://github.com/cosmos/gaia/pull/1208) Update statesync.bash.
-* * (gaia) Bump [Cosmos-SDK](https://github.com/cosmos/cosmos-sdk) to [v0.44.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.6)
+* (gaia) Bump [Cosmos-SDK](https://github.com/cosmos/cosmos-sdk) to [v0.44.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.6)
 * (gaia) Bump [Versions](https://github.com/cosmos/gaia/pull/1100) of various smaller dependencies, remove the Cosmos SDK replace statement, update `initiClientCtx` params, ensure `stdout` and `stderr` are handled correctly in the CLI.
 
 ## [v6.0.3] - 2021-02-18

--- a/ante/ante_test.go
+++ b/ante/ante_test.go
@@ -1,0 +1,99 @@
+package ante_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/stretchr/testify/suite"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	gaiaapp "github.com/cosmos/gaia/v6/app"
+	gaiahelpers "github.com/cosmos/gaia/v6/app/helpers"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	app         *gaiaapp.GaiaApp
+	anteHandler sdk.AnteHandler
+	ctx         sdk.Context
+	clientCtx   client.Context
+	txBuilder   client.TxBuilder
+}
+
+func (s *IntegrationTestSuite) SetupTest() {
+	app := gaiahelpers.Setup(s.T(), false, 1)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{
+		ChainID: fmt.Sprintf("test-chain-%s", tmrand.Str(4)),
+		Height:  1,
+	})
+
+	encodingConfig := simapp.MakeTestEncodingConfig()
+	encodingConfig.Amino.RegisterConcrete(&testdata.TestMsg{}, "testdata.TestMsg", nil)
+	testdata.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	s.app = app
+	s.ctx = ctx
+	s.clientCtx = client.Context{}.WithTxConfig(encodingConfig.TxConfig)
+}
+
+func (s *IntegrationTestSuite) CreateTestTx(privs []cryptotypes.PrivKey, accNums []uint64, accSeqs []uint64, chainID string) (xauthsigning.Tx, error) {
+	var sigsV2 []signing.SignatureV2
+	for i, priv := range privs {
+		sigV2 := signing.SignatureV2{
+			PubKey: priv.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode:  s.clientCtx.TxConfig.SignModeHandler().DefaultMode(),
+				Signature: nil,
+			},
+			Sequence: accSeqs[i],
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+
+	if err := s.txBuilder.SetSignatures(sigsV2...); err != nil {
+		return nil, err
+	}
+
+	sigsV2 = []signing.SignatureV2{}
+	for i, priv := range privs {
+		signerData := xauthsigning.SignerData{
+			ChainID:       chainID,
+			AccountNumber: accNums[i],
+			Sequence:      accSeqs[i],
+		}
+		sigV2, err := tx.SignWithPrivKey(
+			s.clientCtx.TxConfig.SignModeHandler().DefaultMode(),
+			signerData,
+			s.txBuilder,
+			priv,
+			s.clientCtx.TxConfig,
+			accSeqs[i],
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+
+	if err := s.txBuilder.SetSignatures(sigsV2...); err != nil {
+		return nil, err
+	}
+
+	return s.txBuilder.GetTx(), nil
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}

--- a/ante/fee.go
+++ b/ante/fee.go
@@ -1,0 +1,77 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+)
+
+const maxIBCRelayerMsgGasUsage = uint64(200_000)
+
+// MempoolFeeDecorator will check if the transaction's fee is at least as large
+// as the local validator's minimum gasFee (defined in validator config).
+//
+// If fee is too low, decorator returns error and tx is rejected from mempool.
+// Note this only applies when ctx.CheckTx = true. If fee is high enough or not
+// CheckTx, then call next AnteHandler.
+//
+// CONTRACT: Tx must implement FeeTx to use MempoolFeeDecorator
+type MempoolFeeDecorator struct{}
+
+func NewMempoolFeeDecorator() MempoolFeeDecorator {
+	return MempoolFeeDecorator{}
+}
+
+func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feeCoins := feeTx.GetFee()
+	gas := feeTx.GetGas()
+	msgs := feeTx.GetMsgs()
+
+	// Only check for minimum fees if the execution mode is CheckTx and the tx does
+	// not contain IBC relayer messages. If the tx does contain IBC relayer messages,
+	// it's total gas must be less than or equal to a constant, otherwise minimum
+	// fees are checked.
+	if ctx.IsCheckTx() && !simulate && !(isIBCRelayerTx(msgs) && gas <= uint64(len(msgs))*maxIBCRelayerMsgGasUsage) {
+		minGasPrices := ctx.MinGasPrices()
+		if !minGasPrices.IsZero() {
+			requiredFees := make(sdk.Coins, len(minGasPrices))
+
+			// Determine the required fees by multiplying each required minimum gas
+			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+			glDec := sdk.NewDec(int64(gas))
+			for i, gp := range minGasPrices {
+				fee := gp.Amount.Mul(glDec)
+				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
+			}
+
+			if !feeCoins.IsAnyGTE(requiredFees) {
+				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, requiredFees)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func isIBCRelayerTx(msgs []sdk.Msg) bool {
+	for _, msg := range msgs {
+		switch msg.(type) {
+		case *ibctransfertypes.MsgTransfer:
+			continue
+
+		case *ibcclienttypes.MsgUpdateClient:
+			continue
+
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/ante/fee.go
+++ b/ante/fee.go
@@ -3,7 +3,6 @@ package ante
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 )
@@ -63,7 +62,7 @@ func (mfd MempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 func isIBCRelayerTx(msgs []sdk.Msg) bool {
 	for _, msg := range msgs {
 		switch msg.(type) {
-		case *ibctransfertypes.MsgTransfer:
+		case *ibcchanneltypes.MsgRecvPacket:
 			continue
 
 		case *ibcchanneltypes.MsgAcknowledgement:

--- a/ante/fee.go
+++ b/ante/fee.go
@@ -5,6 +5,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	ibcchanneltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 )
 
 const maxIBCRelayerMsgGasUsage = uint64(200_000)
@@ -63,6 +64,9 @@ func isIBCRelayerTx(msgs []sdk.Msg) bool {
 	for _, msg := range msgs {
 		switch msg.(type) {
 		case *ibctransfertypes.MsgTransfer:
+			continue
+
+		case *ibcchanneltypes.MsgAcknowledgement:
 			continue
 
 		case *ibcclienttypes.MsgUpdateClient:

--- a/ante/fee_test.go
+++ b/ante/fee_test.go
@@ -1,0 +1,55 @@
+package ante_test
+
+import (
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	ibcchanneltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
+
+	"github.com/cosmos/gaia/v6/ante"
+)
+
+func (s *IntegrationTestSuite) TestMempoolFeeDecorator() {
+	s.SetupTest()
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewMempoolFeeDecorator()
+	antehandler := sdk.ChainAnteDecorators(mfd)
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+
+	msg := testdata.NewTestMsg(addr1)
+	feeAmount := testdata.NewTestFeeAmount()
+	gasLimit := testdata.NewTestGasLimit()
+	s.Require().NoError(s.txBuilder.SetMsgs(msg))
+	s.txBuilder.SetFeeAmount(feeAmount)
+	s.txBuilder.SetGasLimit(gasLimit)
+
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+
+	// Set high gas price so standard test fee fails
+	feeAmt := sdk.NewDecCoinFromDec("uatom", sdk.NewDec(200).Quo(sdk.NewDec(100000)))
+	minGasPrice := []sdk.DecCoin{feeAmt}
+	s.ctx = s.ctx.WithMinGasPrices(minGasPrice).WithIsCheckTx(true)
+
+	// antehandler errors with insufficient fees
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err, "expected error due to low fee")
+
+	// ensure no fees for certain IBC msgs
+	s.Require().NoError(s.txBuilder.SetMsgs(
+		ibcchanneltypes.NewMsgRecvPacket(ibcchanneltypes.Packet{}, nil, ibcclienttypes.Height{}, ""),
+	))
+
+	oracleTx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	_, err = antehandler(s.ctx, oracleTx, false)
+	s.Require().NoError(err, "expected min fee bypass for IBC messages")
+
+	s.ctx = s.ctx.WithIsCheckTx(false)
+
+	// antehandler should not error since we do not check min gas prices in DeliverTx
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err, "unexpected error during DeliverTx")
+}

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	channelkeeper "github.com/cosmos/ibc-go/v2/modules/core/04-channel/keeper"
 	ibcante "github.com/cosmos/ibc-go/v2/modules/core/ante"
+
+	gaiaante "github.com/cosmos/gaia/v6/ante"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
@@ -35,7 +37,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(),
 		ante.NewRejectExtensionOptionsDecorator(),
-		ante.NewMempoolFeeDecorator(),
+		gaiaante.NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(options.AccountKeeper),

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -10,6 +10,9 @@ import (
 	gaiaante "github.com/cosmos/gaia/v6/ante"
 )
 
+// TODO: Move this to the root ante package after this is backported to 6.x.x
+// release.
+
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
 // channel keeper.
 type HandlerOptions struct {

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -1,6 +1,87 @@
 package helpers
 
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+
+	gaiaapp "github.com/cosmos/gaia/v6/app"
+)
+
 // SimAppChainID hardcoded chainID for simulation
 const (
 	SimAppChainID = "gaia-app"
 )
+
+// DefaultConsensusParams defines the default Tendermint consensus params used
+// in GaiaApp testing.
+var DefaultConsensusParams = &abci.ConsensusParams{
+	Block: &abci.BlockParams{
+		MaxBytes: 200000,
+		MaxGas:   2000000,
+	},
+	Evidence: &tmproto.EvidenceParams{
+		MaxAgeNumBlocks: 302400,
+		MaxAgeDuration:  504 * time.Hour, // 3 weeks is the max duration
+		MaxBytes:        10000,
+	},
+	Validator: &tmproto.ValidatorParams{
+		PubKeyTypes: []string{
+			tmtypes.ABCIPubKeyTypeEd25519,
+		},
+	},
+}
+
+type EmptyAppOptions struct{}
+
+func (EmptyAppOptions) Get(o string) interface{} { return nil }
+
+func Setup(t *testing.T, isCheckTx bool, invCheckPeriod uint) *gaiaapp.GaiaApp {
+	t.Helper()
+
+	app, genesisState := setup(!isCheckTx, invCheckPeriod)
+	if !isCheckTx {
+		// InitChain must be called to stop deliverState from being nil
+		stateBytes, err := json.MarshalIndent(genesisState, "", " ")
+		require.NoError(t, err)
+
+		// Initialize the chain
+		app.InitChain(
+			abci.RequestInitChain{
+				Validators:      []abci.ValidatorUpdate{},
+				ConsensusParams: DefaultConsensusParams,
+				AppStateBytes:   stateBytes,
+			},
+		)
+	}
+
+	return app
+}
+
+func setup(withGenesis bool, invCheckPeriod uint) (*gaiaapp.GaiaApp, gaiaapp.GenesisState) {
+	db := dbm.NewMemDB()
+	encCdc := gaiaapp.MakeEncodingConfig()
+	app := gaiaapp.NewGaiaApp(
+		log.NewNopLogger(),
+		db,
+		nil,
+		true,
+		map[int64]bool{},
+		gaiaapp.DefaultNodeHome,
+		invCheckPeriod,
+		encCdc,
+		EmptyAppOptions{},
+	)
+	if withGenesis {
+		return app, gaiaapp.NewDefaultGenesisState()
+	}
+
+	return app, gaiaapp.GenesisState{}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/gorilla/mux v1.8.0
-	github.com/ory/dockertest/v3 v3.8.1
 	github.com/gravity-devs/liquidity v1.4.6
+	github.com/ory/dockertest/v3 v3.8.1
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.3.0


### PR DESCRIPTION
Bypass validator min fee check during `CheckTx` iff:

- Contains `MsgRecvPacket`, `MsgAcknowledgement`, and `MsgUpdateClient` only
- Given the above is true, the total gas is less than some constant