### PR TITLE
docs: Quickfix show search bar above 1136px window width (vuepress/docs only) 

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,3 +1,12 @@
+// temporary search bar fix
+.search__container
+  visibility visible!important
+
+.layout__main__content__aside__container
+  margin-top 60px
+
+
+
 .tabs-component
   margin 2em 0
 

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -5,6 +5,9 @@
 .layout__main__content__aside__container
   margin-top 60px
 
+#aside-scroll .container .search__container
+  display none
+
 
 
 .tabs-component


### PR DESCRIPTION
This fixes #1162 

![image](https://user-images.githubusercontent.com/260038/160169763-f10a0914-b2e6-4fe7-b15c-8bd1e9286f36.png)

Quickfix by adjusting/overwriting css definitions through the `index.styl` file. Long-term, this should be fixed in the [vuepress-theme-cosmos](https://github.com/cosmos/vuepress-theme-cosmos) repo.