### PR TITLE
expose GRPC and REST endpoints from a single docker testnet node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: "tendermint/gaiadnode"
     ports:
       - "26656-26657:26656-26657"
+      - "9090:9090"
+      - "1317:1317"
     environment:
       - ID=0
       - LOG=${LOG:-gaiad.log}


### PR DESCRIPTION
Small UX improvement. Have the GRPC (9090) and REST (1317) ports exposed on a single node so developers doing local integration work can automatically hit these endpoints.