### PR TITLE
Update build-docker-gaiadnode to point to correct Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ format:
 ###############################################################################
 
 build-docker-gaiadnode:
-	$(MAKE) -C networks/local
+	$(MAKE) -C contrib/testnets/local
 
 # Run a 4-node testnet locally
 localnet-start: build-linux localnet-stop


### PR DESCRIPTION
The network/local Makefile was moved to contrib/testnets/local in https://github.com/cosmos/gaia/pull/992.