### PR TITLE
Rename quickstart to make purpose clear

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,7 +2,7 @@
 order: 3
 -->
 
-# Quick Start
+# Join Mainnet Quick Start
 
 **Bootstrap a  `cosmoshub-4` mainnet node**
 


### PR DESCRIPTION
Updating the title of this document to make the purpose of the guide clearer to newcomers.