### PR TITLE
Docs: fix sidebar order and YAML front matter formatting

### DIFF
--- a/docs/delegators/README.md
+++ b/docs/delegators/README.md
@@ -1,8 +1,9 @@
-<!---
+---
 order: false
 parent:
+  title: Delegators
   order: 4
---->
+---
 
 # Delegators
 

--- a/docs/delegators/delegator-faq.md
+++ b/docs/delegators/delegator-faq.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 2
--->
+title: Delegator FAQ
+---
 
 # Delegator FAQ
 

--- a/docs/delegators/delegator-guide-cli.md
+++ b/docs/delegators/delegator-guide-cli.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 1
--->
+title: Delegator Guide (CLI)
+---
 
 # Delegator Guide (CLI)
 

--- a/docs/delegators/delegator-security.md
+++ b/docs/delegators/delegator-security.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 3
--->
+title: Delegator Security
+---
 
 # Delegator Security
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,8 +1,8 @@
-<!--
+---
 order: false
 parent:
   order: 2
--->
+---
 
 # Getting Started
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 2
--->
+title: Installing Gaia
+---
 
 # Installation
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 3
--->
+title: Quick Start - Join Mainnet 
+---
 
 # Join Mainnet Quick Start
 

--- a/docs/getting-started/what-is-gaia.md
+++ b/docs/getting-started/what-is-gaia.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 1
--->
+title: What is Gaia?
+---
 
 # What is Gaia?
 

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,9 +1,9 @@
-<!--
+---
 order: 1
 parent:
   title: Governance
   order: 6
--->
+---
 
 # Governance Overview
 

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,9 +1,9 @@
----
+<!--
 order: 1
 parent:
   title: Governance
-  order: 7
----
+  order: 6
+-->
 
 # Governance Overview
 

--- a/docs/hub-overview/README.md
+++ b/docs/hub-overview/README.md
@@ -1,8 +1,8 @@
-<!--
+---
 order: false
 parent:
   order: 1
--->
+---
 
 # Cosmos Hub
 

--- a/docs/hub-overview/overview.md
+++ b/docs/hub-overview/overview.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 1
--->
+title: Introduction
+---
 
 ![Welcome to the Cosmos Hub](../images/cosmos-hub-image.jpg)
 

--- a/docs/hub-tutorials/README.md
+++ b/docs/hub-tutorials/README.md
@@ -1,7 +1,7 @@
 <!--
 order: false
 parent:
-  order: 1
+  order: 3
 -->
 
 # Gaia Tutorials

--- a/docs/hub-tutorials/README.md
+++ b/docs/hub-tutorials/README.md
@@ -1,8 +1,8 @@
-<!--
+---
 order: false
 parent:
   order: 3
--->
+---
 
 # Gaia Tutorials
 

--- a/docs/hub-tutorials/gaiad.md
+++ b/docs/hub-tutorials/gaiad.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 5
--->
+title: Interacting with Gaiad (CLI)
+---
 
 # Gaia Client
 

--- a/docs/hub-tutorials/join-mainnet.md
+++ b/docs/hub-tutorials/join-mainnet.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 2
--->
+title: Joining Mainnet
+---
 
 # Join the Cosmos Hub Mainnet
 

--- a/docs/hub-tutorials/join-testnet.md
+++ b/docs/hub-tutorials/join-testnet.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 3
--->
+title: Joining Testnet
+---
 
 # Join the Public Testnet
 

--- a/docs/hub-tutorials/live-upgrade-tutorial.md
+++ b/docs/hub-tutorials/live-upgrade-tutorial.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 6
--->
+title: Upgrading the Chain
+---
 
 # Live Upgrade Tutorial
 

--- a/docs/hub-tutorials/upgrade-node.md
+++ b/docs/hub-tutorials/upgrade-node.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 4
--->
+title: Upgrading Your Node
+---
 
 # Upgrade Your Node
 
@@ -8,7 +9,7 @@ This document describes the upgrade procedure of a `gaiad` full-node to a new ve
 
 ## Cosmovisor
 
-The CosmosSDK provides a convenient process manager that wraps around the `gaiad` binary and can automatically swap in new binaries upon a successful governance upgrade proposal. Cosmovisor is entirely optional but recommended. More information can be found in [cosmos.network docs](https://docs.cosmos.network/master/run-node/cosmovisor.html) and [cosmos-sdk/cosmovisor/readme](https://github.com/cosmos/cosmos-sdk/blob/master/cosmovisor/README.md).
+The Cosmos SDK provides a convenient process manager that wraps around the `gaiad` binary and can automatically swap in new binaries upon a successful governance upgrade proposal. Cosmovisor is entirely optional but recommended. More information can be found in [cosmos.network docs](https://docs.cosmos.network/master/run-node/cosmovisor.html) and [cosmos-sdk/cosmovisor/readme](https://github.com/cosmos/cosmos-sdk/blob/master/cosmovisor/README.md).
 
 ### Setup
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,6 +1,8 @@
 <!--
+order: false
 parent:
-  order: false
+  title: Migration Instructions
+  order: 9
 markdown-link-check-disable
 -->
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,8 +1,10 @@
-<!--
+---
 order: false
 parent:
   title: Migration Instructions
   order: 9
+---
+<!--
 markdown-link-check-disable
 -->
 

--- a/docs/migration/breaking_changes.md
+++ b/docs/migration/breaking_changes.md
@@ -1,3 +1,7 @@
+<!--
+title: Breaking Changes
+order: 1
+-->
 <!-- markdown-link-check-disable -->
 # Breaking Changes
 

--- a/docs/migration/breaking_changes.md
+++ b/docs/migration/breaking_changes.md
@@ -1,7 +1,7 @@
-<!--
+---
 title: Breaking Changes
 order: 1
--->
+---
 <!-- markdown-link-check-disable -->
 # Breaking Changes
 

--- a/docs/migration/cosmoshub-2.md
+++ b/docs/migration/cosmoshub-2.md
@@ -1,3 +1,7 @@
+<!--
+title: Cosmos Hub 2 Upgrade
+order: 6
+-->
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 2 Upgrade Instructions
 

--- a/docs/migration/cosmoshub-2.md
+++ b/docs/migration/cosmoshub-2.md
@@ -1,7 +1,7 @@
-<!--
+---
 title: Cosmos Hub 2 Upgrade
 order: 6
--->
+---
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 2 Upgrade Instructions
 

--- a/docs/migration/cosmoshub-3.md
+++ b/docs/migration/cosmoshub-3.md
@@ -1,7 +1,7 @@
-<!--
+---
 title: Cosmos Hub 3 Upgrade
 order: 5
--->
+---
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 3 Upgrade Instructions
 

--- a/docs/migration/cosmoshub-3.md
+++ b/docs/migration/cosmoshub-3.md
@@ -1,3 +1,7 @@
+<!--
+title: Cosmos Hub 3 Upgrade
+order: 5
+-->
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 3 Upgrade Instructions
 

--- a/docs/migration/cosmoshub-3[ES_es].md
+++ b/docs/migration/cosmoshub-3[ES_es].md
@@ -1,3 +1,6 @@
+<!--
+order: false
+-->
 <!-- markdown-link-check-disable -->
 # Instrucciones de actualización del Cosmos Hub 3
 

--- a/docs/migration/cosmoshub-3[ES_es].md
+++ b/docs/migration/cosmoshub-3[ES_es].md
@@ -1,6 +1,6 @@
-<!--
+---
 order: false
--->
+---
 <!-- markdown-link-check-disable -->
 # Instrucciones de actualización del Cosmos Hub 3
 

--- a/docs/migration/cosmoshub-3[KR_kr].md
+++ b/docs/migration/cosmoshub-3[KR_kr].md
@@ -1,3 +1,6 @@
+<!--
+order: false
+-->
 <!-- markdown-link-check-disable -->
 # 코스모스 허브 3 업그레이드 매뉴얼
 

--- a/docs/migration/cosmoshub-3[KR_kr].md
+++ b/docs/migration/cosmoshub-3[KR_kr].md
@@ -1,6 +1,6 @@
-<!--
+---
 order: false
--->
+---
 <!-- markdown-link-check-disable -->
 # 코스모스 허브 3 업그레이드 매뉴얼
 

--- a/docs/migration/cosmoshub-4-delta-upgrade.md
+++ b/docs/migration/cosmoshub-4-delta-upgrade.md
@@ -1,7 +1,7 @@
-<!--
+---
 title: Cosmos Hub 4, Delta Upgrade
 order: 4
--->
+---
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 4, Delta Upgrade, Instructions
 

--- a/docs/migration/cosmoshub-4-delta-upgrade.md
+++ b/docs/migration/cosmoshub-4-delta-upgrade.md
@@ -1,3 +1,7 @@
+<!--
+title: Cosmos Hub 4, Delta Upgrade
+order: 4
+-->
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 4, Delta Upgrade, Instructions
 

--- a/docs/migration/cosmoshub-4-v7-Theta-upgrade.md
+++ b/docs/migration/cosmoshub-4-v7-Theta-upgrade.md
@@ -1,3 +1,7 @@
+<!--
+title: Cosmos Hub 4, Theta Upgrade
+order: 2
+-->
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 4, v7-Theta Upgrade, Instructions
 

--- a/docs/migration/cosmoshub-4-v7-Theta-upgrade.md
+++ b/docs/migration/cosmoshub-4-v7-Theta-upgrade.md
@@ -1,7 +1,7 @@
-<!--
+---
 title: Cosmos Hub 4, Theta Upgrade
 order: 2
--->
+---
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 4, v7-Theta Upgrade, Instructions
 

--- a/docs/migration/cosmoshub-4-vega-upgrade.md
+++ b/docs/migration/cosmoshub-4-vega-upgrade.md
@@ -1,7 +1,7 @@
-<!--
+---
 title: Cosmos Hub 4, Vega Upgrade
 order: 3
--->
+---
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 4, Vega Upgrade, Instructions
 

--- a/docs/migration/cosmoshub-4-vega-upgrade.md
+++ b/docs/migration/cosmoshub-4-vega-upgrade.md
@@ -1,3 +1,7 @@
+<!--
+title: Cosmos Hub 4, Vega Upgrade
+order: 3
+-->
 <!-- markdown-link-check-disable -->
 # Cosmos Hub 4, Vega Upgrade, Instructions
 

--- a/docs/readiness/README.md
+++ b/docs/readiness/README.md
@@ -1,5 +1,8 @@
 <!--
 order: 1
+parent:
+  title: Architecture Decision Records (ADR)
+  order: 10
 -->
 
 # Architecture Decision Records (ADR)

--- a/docs/readiness/template.md
+++ b/docs/readiness/template.md
@@ -1,6 +1,5 @@
 <!--
-parent:
-  order: false
+order: false
 -->
 
 ---

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -1,7 +1,8 @@
 <!--
 order: false
 parent:
-  order: 6
+  title: resources
+  order: 8
 -->
 
 # Resources

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -1,9 +1,9 @@
-<!--
+---
 order: false
 parent:
-  title: resources
+  title: Resources
   order: 8
--->
+---
 
 # Resources
 

--- a/docs/resources/archives.md
+++ b/docs/resources/archives.md
@@ -1,6 +1,7 @@
-<!--
-order: 7
--->
+---
+order: 2
+title: Cosmos Hub Archives
+---
 
 # Cosmos Hub Archives
 

--- a/docs/resources/genesis.md
+++ b/docs/resources/genesis.md
@@ -1,6 +1,7 @@
-<!--
-order: 2
--->
+---
+order: 1
+title: The Genesis File
+---
 
 # Genesis File
 

--- a/docs/resources/hd-wallets.md
+++ b/docs/resources/hd-wallets.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 3
--->
+title: HD Wallets
+---
 
 # HD Wallets
 

--- a/docs/resources/ledger.md
+++ b/docs/resources/ledger.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 4
--->
+title: Ledger Support
+---
 
 # Ledger Nano Support
 

--- a/docs/resources/reproducible-builds.md
+++ b/docs/resources/reproducible-builds.md
@@ -1,6 +1,7 @@
-<!--
-order: 6
--->
+---
+order: 5
+title: Building Gaia Deterministically
+---
 
 # Build Gaia Deterministically
 

--- a/docs/resources/service-providers.md
+++ b/docs/resources/service-providers.md
@@ -1,6 +1,7 @@
-<!--
-order: 5
--->
+---
+order: 6
+title: Service Providers
+---
 
 # Service Providers
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,7 +1,8 @@
 <!--
 order: false
 parent:
-  order: 8
+  title: Roadmap
+  order: 7
 -->
 
 # Roadmap

--- a/docs/validators/README.md
+++ b/docs/validators/README.md
@@ -1,9 +1,9 @@
-<!--
+---
 order: false
 parent:
   title: Validators
   order: 5
--->
+---
 
 # Validators
 

--- a/docs/validators/README.md
+++ b/docs/validators/README.md
@@ -1,6 +1,7 @@
 <!--
 order: false
 parent:
+  title: Validators
   order: 5
 -->
 

--- a/docs/validators/overview.md
+++ b/docs/validators/overview.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 1
--->
+title: Overview
+---
 
 # Validators Overview
 

--- a/docs/validators/security.md
+++ b/docs/validators/security.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 4
--->
+title: Validator Security
+---
 
 # Validator Security
 

--- a/docs/validators/validator-faq.md
+++ b/docs/validators/validator-faq.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 3
--->
+title: Validator FAQ
+---
 
 # Validator FAQ
 

--- a/docs/validators/validator-setup.md
+++ b/docs/validators/validator-setup.md
@@ -1,6 +1,7 @@
-<!--
+---
 order: 2
--->
+title: Running a Validator
+---
 
 # Running a Validator
 


### PR DESCRIPTION
Lot of docs had incorrect YAML front matter formatting. Changed some display titles and re-ordered some docs within some folders. Migrations folder had really broken titles as well.

Tested locally and looks good: 
<img width="254" alt="Screenshot 2022-05-18 at 18 40 33" src="https://user-images.githubusercontent.com/81436914/169096571-f9bcd38d-8dc9-49be-b352-14b6138db963.png">

