### PR TITLE
closes #916, addes gh action for docker push to ghcr

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,42 @@
+# source: https://docs.github.com/en/enterprise-cloud@latest/actions/publishing-packages/publishing-docker-images
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['release']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+ARG IMG_TAG=latest
+
+# Compile the gaiad binary
+FROM golang:1.18-alpine AS gaiad-builder
+WORKDIR /src/app/
+COPY go.mod go.sum* ./
+RUN go mod download
+COPY . .
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+RUN apk add --no-cache $PACKAGES
+RUN CGO_ENABLED=0 make install
+
+# Add to a distroless container
+FROM gcr.io/distroless/cc:$IMG_TAG
+ARG IMG_TAG
+COPY --from=gaiad-builder /go/bin/gaiad /usr/local/bin/
+EXPOSE 26656 26657 1317 9090
+
+ENTRYPOINT ["gaiad", "start", "--mode", "validator"]


### PR DESCRIPTION
Issue:  #916 
This pr adds a GitHub action that will publish images to the cosmos ghcr registry.

The GitHub action and metadata defaults are as per: `https://docs.github.com/en/actions/publishing-packages/publishing-docker-images` 
Expected  naming convention: `cosmos/gaia@latest, cosmos/gaia@7.0.2`
 