### PR TITLE
create fallback default bypass min fee messages

### DIFF
--- a/cmd/gaiad/cmd/root.go
+++ b/cmd/gaiad/cmd/root.go
@@ -28,8 +28,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 
-	// ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
-	// ibcchanneltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
@@ -101,12 +99,8 @@ func initAppConfig() (string, interface{}) {
 	srvCfg.StateSync.SnapshotKeepRecent = 10
 
 	return params.CustomConfigTemplate, params.CustomAppConfig{
-		Config: *srvCfg,
-		// BypassMinFeeMsgTypes: []string{
-		// 	sdk.MsgTypeURL(&ibcchanneltypes.MsgRecvPacket{}),
-		// 	sdk.MsgTypeURL(&ibcchanneltypes.MsgAcknowledgement{}),
-		// 	sdk.MsgTypeURL(&ibcclienttypes.MsgUpdateClient{}),
-		// },
+		Config:               *srvCfg,
+		BypassMinFeeMsgTypes: gaia.GetDefaultBypassFeeMessages(),
 	}
 }
 


### PR DESCRIPTION
Based on the discussion [here](https://github.com/cosmos/gaia/pull/1539#pullrequestreview-1019995309) these changes should make it possible to fall back to a default set of bypass min fee messages so that if a node operator hasn't added the new value to their config file, the default is used.