### PR TITLE
swap out ignite for liveness test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,10 +95,10 @@ jobs:
         if: env.GIT_DIFF
       - name: Start Local Network
         run: |
-          make start-localnet-ci > liveness.out 2>&1 &
+          make start-localnet-ci
         if: env.GIT_DIFF
       - name: Test Local Network Liveness
         run: |
-          sleep 3m
+          sleep 1m
           ./contrib/scripts/test_localnet_liveness.sh 100 5 50 localhost
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,5 @@ jobs:
         if: env.GIT_DIFF
       - name: Test Local Network Liveness
         run: |
-          sleep 1m
           ./contrib/scripts/test_localnet_liveness.sh 100 5 50 localhost
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,13 +89,13 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - name: Install Ignite CLI
+      - name: Install Gaia
         run: |
-          curl https://get.ignite.com/cli@v0.21.1! | bash
+          make build
         if: env.GIT_DIFF
-      - name: Start Local Network via Ignite CLI
+      - name: Start Local Network
         run: |
-          make start-localnet-ci > ignite.out 2>&1 &
+          make start-localnet-ci > liveness.out 2>&1 &
         if: env.GIT_DIFF
       - name: Test Local Network Liveness
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
         if: env.GIT_DIFF
       - name: Start Local Network
         run: |
-          make start-localnet-ci
+          make start-localnet-ci > liveness.out 2>&1 &
         if: env.GIT_DIFF
       - name: Test Local Network Liveness
         run: |

--- a/Makefile
+++ b/Makefile
@@ -226,15 +226,15 @@ start-localnet-ci:
 	ls ${GOPATH}
 	ls ${GOPATH}/bin
 	ls build
-	${GOPATH}/bin/gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
-	${GOPATH}/bin/gaiad config chain-id liveness --home ~/.gaiad-liveness
-	${GOPATH}/bin/gaiad config keyring-backend test --home ~/.gaiad-liveness
-	${GOPATH}/bin/gaiad keys add val --home ~/.gaiad-liveness
-	${GOPATH}/bin/gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
-	${GOPATH}/bin/gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
-	${GOPATH}/bin/gaiad collect-gentxs --home ~/.gaiad-liveness 
+	./build/gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
+	./build/gaiad config chain-id liveness --home ~/.gaiad-liveness
+	./build/gaiad config keyring-backend test --home ~/.gaiad-liveness
+	./build/gaiad keys add val --home ~/.gaiad-liveness
+	./build/gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
+	./build/gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
+	./build/gaiad collect-gentxs --home ~/.gaiad-liveness 
 	sed -i '.bak' 's/minimum-gas-prices = ""/minimum-gas-prices = "0uatom"/' ~/.gaiad-liveness/config/app.toml
-	${GOPATH}/bin/gaiad start --home ~/.gaiad-liveness --mode validator
+	./build/gaiad start --home ~/.gaiad-liveness --mode validator
 
 .PHONY: start-localnet-ci
 

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,7 @@ start-localnet-ci:
 	go env
 	ls ${GOPATH}
 	ls ${GOPATH}/bin
+	ls ${GOPATH}/pkg
 	ls build
 	./build/gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
 	./build/gaiad config chain-id liveness --home ~/.gaiad-liveness

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,14 @@ format:
 ###############################################################################
 
 start-localnet-ci:
-	@ignite chain serve --reset-once -v -c ./ignite.ci.yml
+	gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
+	gaiad config chain-id liveness --home ~/.gaiad-liveness
+	gaiad config keyring-backend test --home ~/.gaiad-liveness
+	gaiad keys add val --home ~/.gaiad-liveness
+	gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
+	gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
+	gaiad collect-gentxs --home ~/.gaiad-liveness 
+	gaiad start --home ~/.gaiad-liveness
 
 .PHONY: start-localnet-ci
 

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ start-localnet-ci:
 	gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
 	gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
 	gaiad collect-gentxs --home ~/.gaiad-liveness 
+	sed -i '.bak' 's/minimum-gas-prices = ""/minimum-gas-prices = "0uatom"/' ~/.gaiad-liveness/config/app.toml
 	gaiad start --home ~/.gaiad-liveness
 
 .PHONY: start-localnet-ci

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ format:
 ###############################################################################
 
 start-localnet-ci:
-	ls -alh
+	go env
+	ls -alh build
 	which go
 	gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
 	gaiad config chain-id liveness --home ~/.gaiad-liveness

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,9 @@ format:
 
 start-localnet-ci:
 	go env
+	ls ${GOPATH}
+	ls ${GOPATH}/bin
+	ls build
 	${GOPATH}/bin/gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
 	${GOPATH}/bin/gaiad config chain-id liveness --home ~/.gaiad-liveness
 	${GOPATH}/bin/gaiad config keyring-backend test --home ~/.gaiad-liveness

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ start-localnet-ci:
 	gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
 	gaiad collect-gentxs --home ~/.gaiad-liveness 
 	sed -i '.bak' 's/minimum-gas-prices = ""/minimum-gas-prices = "0uatom"/' ~/.gaiad-liveness/config/app.toml
-	gaiad start --home ~/.gaiad-liveness
+	gaiad start --home ~/.gaiad-liveness --mode validator
 
 .PHONY: start-localnet-ci
 

--- a/Makefile
+++ b/Makefile
@@ -234,8 +234,8 @@ start-localnet-ci:
 	./build/gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
 	./build/gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
 	./build/gaiad collect-gentxs --home ~/.gaiad-liveness 
-	sed -i '.bak' 's/minimum-gas-prices = ""/minimum-gas-prices = "0uatom"/' ~/.gaiad-liveness/config/app.toml
-	./build/gaiad start --home ~/.gaiad-liveness --mode validator
+	sed -i'' 's/minimum-gas-prices = ""/minimum-gas-prices = "0uatom"/' ~/.gaiad-liveness/config/app.toml
+	./build/gaiad start --home ~/.gaiad-liveness --mode validator --x-crisis-skip-assert-invariants
 
 .PHONY: start-localnet-ci
 

--- a/Makefile
+++ b/Makefile
@@ -223,17 +223,15 @@ format:
 
 start-localnet-ci:
 	go env
-	ls -alh build
-	which go
-	gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
-	gaiad config chain-id liveness --home ~/.gaiad-liveness
-	gaiad config keyring-backend test --home ~/.gaiad-liveness
-	gaiad keys add val --home ~/.gaiad-liveness
-	gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
-	gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
-	gaiad collect-gentxs --home ~/.gaiad-liveness 
+	${GOPATH}/bin/gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
+	${GOPATH}/bin/gaiad config chain-id liveness --home ~/.gaiad-liveness
+	${GOPATH}/bin/gaiad config keyring-backend test --home ~/.gaiad-liveness
+	${GOPATH}/bin/gaiad keys add val --home ~/.gaiad-liveness
+	${GOPATH}/bin/gaiad add-genesis-account val 10000000000000000000000000stake --home ~/.gaiad-liveness --keyring-backend test
+	${GOPATH}/bin/gaiad gentx val 1000000000stake --home ~/.gaiad-liveness --chain-id liveness
+	${GOPATH}/bin/gaiad collect-gentxs --home ~/.gaiad-liveness 
 	sed -i '.bak' 's/minimum-gas-prices = ""/minimum-gas-prices = "0uatom"/' ~/.gaiad-liveness/config/app.toml
-	gaiad start --home ~/.gaiad-liveness --mode validator
+	${GOPATH}/bin/gaiad start --home ~/.gaiad-liveness --mode validator
 
 .PHONY: start-localnet-ci
 

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,8 @@ format:
 ###############################################################################
 
 start-localnet-ci:
+	ls -alh
+	which go
 	gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
 	gaiad config chain-id liveness --home ~/.gaiad-liveness
 	gaiad config keyring-backend test --home ~/.gaiad-liveness

--- a/Makefile
+++ b/Makefile
@@ -222,11 +222,6 @@ format:
 ###############################################################################
 
 start-localnet-ci:
-	go env
-	ls ${GOPATH}
-	ls ${GOPATH}/bin
-	ls ${GOPATH}/pkg
-	ls build
 	./build/gaiad init liveness --chain-id liveness --home ~/.gaiad-liveness
 	./build/gaiad config chain-id liveness --home ~/.gaiad-liveness
 	./build/gaiad config keyring-backend test --home ~/.gaiad-liveness

--- a/app/app.go
+++ b/app/app.go
@@ -761,7 +761,7 @@ func NewGaiaApp(
 			ctx.Logger().Info("start to init interchainaccount module...")
 			// initialize ICS27 module
 			icaModule.InitModule(ctx, controllerParams, hostParams)
-			ctx.Logger().Info("start to run module migrations...")
+			ctx.Logger().Info("Start to run module migrations...")
 
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		},

--- a/contrib/scripts/test_localnet_liveness.sh
+++ b/contrib/scripts/test_localnet_liveness.sh
@@ -30,6 +30,8 @@ if [ -z "$4" ]; then
   exit 1
 fi
 
+echo "running 'sh test_localnet_liveness.sh iterations=$ITER sleep=$SLEEP num-blocks=$NUMBLOCKS node-address=$NODEADDR'"
+
 docker_containers=($(docker ps -q -f name=umeed --format='{{.Names}}'))
 
 while [ ${CNT} -lt $ITER ]; do

--- a/contrib/scripts/test_localnet_liveness.sh
+++ b/contrib/scripts/test_localnet_liveness.sh
@@ -36,6 +36,8 @@ docker_containers=($(docker ps -q -f name=umeed --format='{{.Names}}'))
 
 while [ ${CNT} -lt $ITER ]; do
   curr_block=$(curl -s $NODEADDR:26657/status | jq -r '.result.sync_info.latest_block_height')
+  
+  tail liveness.out
 
   if [ ! -z ${curr_block} ]; then
     echo "Current block: ${curr_block}"


### PR DESCRIPTION
currently fails as it tries to run `go mod tidy` but gets the following error:
```
go mod tidy: go.mod file indicates go 1.18, but maximum supported version is 1.17
```