### PR TITLE
Fix formatting in join-testnet.md

### DIFF
--- a/docs/hub-tutorials/join-testnet.md
+++ b/docs/hub-tutorials/join-testnet.md
@@ -112,7 +112,7 @@ The following script installs, configures and starts Cosmovisor:
 ```
 # Install Cosmovisor
 go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor
-
+```
 > NOTE: If you ran a full node on a previous testnet, please skip to [Upgrading From Previous Testnet](#upgrading-from-previous-testnet).
 
 To start a new node, the mainnet instructions apply:


### PR DESCRIPTION
The code block endquote was missing, causing the page to have weird formatting.

![Screen Shot 2022-07-15 at 8 38 31 AM](https://user-images.githubusercontent.com/5478483/179257746-56bc8344-c0c0-452b-bf69-927588a2c162.png)

