### PR TITLE
Correcting the email address in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-`contact@interchain.berlin`.
+`hello@interchain.io`.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
contact@interchain.berlin is no longer active/monitored. Changing to hello@interchain.io.

Not considering this to be a material change to the CoC