### PR TITLE
ci: Update lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --out-format=tab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,3 @@ jobs:
         with:
           version: latest
           args: --out-format=tab
-          skip-go-installation: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,26 @@
-name: Lint
-# Lint runs golangci-lint over the entire gaia repository
-# This workflow is run on every pull request and push to main
-# The `golangci` will pass without running if no *.{go, mod, sum} files have been changed.
+name: golangci-lint
 on:
-  pull_request:
   push:
+    tags:
+      - v*
     branches:
       - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
 jobs:
   golangci:
-    name: golangci-lint
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,15 +15,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: technote-space/get-diff-action@v6.0.1
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - name: golangci-lint
-        if: env.GIT_DIFF
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest


### PR DESCRIPTION
The git diff thing causes linter errors to be grandfathered in. 

It hasn't been firing, and that's why we didn't know until now that the new configuration doesn't work at all. 

Time isn't a concern here, as codeql and e2e both take significantly longer.  We should lint on each commit, and we should not use diffs to determine weather or not we lint otherwise, it is likely we aren't actually linting.

* #1449 

linter runtime: 2m 19s