### PR TITLE
Morelint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --out-format=tab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,3 @@ jobs:
         with:
           version: latest
           args: --out-format=tab
-          skip-go-installation: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,26 @@
-name: Lint
-# Lint runs golangci-lint over the entire gaia repository
-# This workflow is run on every pull request and push to main
-# The `golangci` will pass without running if no *.{go, mod, sum} files have been changed.
+name: golangci-lint
 on:
-  pull_request:
   push:
+    tags:
+      - v*
     branches:
       - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
 jobs:
   golangci:
-    name: golangci-lint
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,15 +15,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: technote-space/get-diff-action@v6.0.1
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - name: golangci-lint
-        if: env.GIT_DIFF
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest

--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	encodingConfig params.EncodingConfig
-	cdc            codec.Codec
+	cdc            codec.Codec //nolint:unused // this is called during e2e tests
 )
 
 func init() {
@@ -42,12 +42,14 @@ func init() {
 	cdc = encodingConfig.Codec
 }
 
+//nolint:unused // this is called during e2e tests
 type chain struct {
 	dataDir    string
 	id         string
 	validators []*validator
 }
 
+//nolint:unused,deadcode // this is called during e2e tests
 func newChain() (*chain, error) {
 	tmpDir, err := ioutil.TempDir("", "gaia-e2e-testnet-")
 	if err != nil {
@@ -60,10 +62,12 @@ func newChain() (*chain, error) {
 	}, nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (c *chain) configDir() string {
 	return fmt.Sprintf("%s/%s", c.dataDir, c.id)
 }
 
+//nolint:unused // this is called during e2e tests
 func (c *chain) createAndInitValidators(count int) error {
 	for i := 0; i < count; i++ {
 		node := c.createValidator(i)
@@ -90,6 +94,7 @@ func (c *chain) createAndInitValidators(count int) error {
 	return nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (c *chain) createAndInitValidatorsWithMnemonics(count int, mnemonics []string) error {
 	for i := 0; i < count; i++ {
 		// create node
@@ -117,6 +122,7 @@ func (c *chain) createAndInitValidatorsWithMnemonics(count int, mnemonics []stri
 	return nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (c *chain) createValidator(index int) *validator {
 	return &validator{
 		chain:   c,

--- a/tests/e2e/e2e_cli_util.go
+++ b/tests/e2e/e2e_cli_util.go
@@ -83,7 +83,7 @@ func queryGaiaDenomBalance(endpoint, addr, denom string) (sdk.Coin, error) {
 		"%s/cosmos/bank/v1beta1/balances/%s/by_denom?denom=%s",
 		endpoint, addr, denom,
 	)
-	resp, err := http.Get(path)
+	resp, err := http.Get(path) //nolint:gosec // this is used as a part of the e2e suite.
 	if err != nil {
 		return zeroCoin, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}

--- a/tests/e2e/e2e_cli_util.go
+++ b/tests/e2e/e2e_cli_util.go
@@ -12,6 +12,7 @@ import (
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
+//nolint:unused,deadcode // this is called during e2e tests
 func queryGaiaTx(endpoint, txHash string) error {
 	resp, err := http.Get(fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", endpoint, txHash))
 	if err != nil {
@@ -37,6 +38,7 @@ func queryGaiaTx(endpoint, txHash string) error {
 	return nil
 }
 
+//nolint:unused,deadcode // this is called during e2e tests
 func getSpecificBalance(endpoint, addr, denom string) (amt sdk.Coin, err error) {
 	balances, err := queryGaiaAllBalances(endpoint, addr)
 	if err != nil {
@@ -51,6 +53,7 @@ func getSpecificBalance(endpoint, addr, denom string) (amt sdk.Coin, err error) 
 	return amt, nil
 }
 
+//nolint:unused // this is called during e2e tests
 func queryGaiaAllBalances(endpoint, addr string) (sdk.Coins, error) {
 	resp, err := http.Get(fmt.Sprintf("%s/cosmos/bank/v1beta1/balances/%s", endpoint, addr))
 	if err != nil {
@@ -72,6 +75,7 @@ func queryGaiaAllBalances(endpoint, addr string) (sdk.Coins, error) {
 	return balancesResp.Balances, nil
 }
 
+//nolint:unused,deadcode // this is called during e2e tests
 func queryGaiaDenomBalance(endpoint, addr, denom string) (sdk.Coin, error) {
 	var zeroCoin sdk.Coin
 
@@ -99,11 +103,12 @@ func queryGaiaDenomBalance(endpoint, addr, denom string) (sdk.Coin, error) {
 	return *balanceResp.Balance, nil
 }
 
-func queryGovProposal(endpoint string, proposalId int) (govv1beta1.QueryProposalResponse, error) {
+//nolint:unused,deadcode // this is called during e2e tests
+func queryGovProposal(endpoint string, proposalID int) (govv1beta1.QueryProposalResponse, error) {
 	var emptyProp govv1beta1.QueryProposalResponse
 
-	path := fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals/%d", endpoint, proposalId)
-	resp, err := http.Get(path)
+	path := fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals/%d", endpoint, proposalID)
+	resp, err := http.Get(path) //nolint:gosec // this is only used during tests
 	if err != nil {
 		return emptyProp, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}

--- a/tests/e2e/genesis.go
+++ b/tests/e2e/genesis.go
@@ -17,6 +17,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
+//nolint:unused // this is called during e2e tests
 func getGenDoc(path string) (*tmtypes.GenesisDoc, error) {
 	serverCtx := server.NewDefaultContext()
 	config := serverCtx.Config
@@ -41,6 +42,7 @@ func getGenDoc(path string) (*tmtypes.GenesisDoc, error) {
 	return doc, nil
 }
 
+//nolint:unused,deadcode // this is called during e2e tests
 func addGenesisAccount(path, moniker, amountStr string, accAddr sdk.AccAddress) error {
 	serverCtx := server.NewDefaultContext()
 	config := serverCtx.Config

--- a/tests/e2e/io.go
+++ b/tests/e2e/io.go
@@ -7,6 +7,7 @@ import (
 	"os"
 )
 
+//nolint:unused,deadcode // this is called during e2e tests
 func copyFile(src, dst string) (int64, error) {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
@@ -33,11 +34,12 @@ func copyFile(src, dst string) (int64, error) {
 	return nBytes, err
 }
 
+//nolint:unused,deadcode // this is called during e2e tests
 func writeFile(path string, body []byte) error {
 	_, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(path, body, 0o644)
+	return ioutil.WriteFile(path, body, 0o644) //nolint:gosec //common cosmos issue, but does not work at 600.
 }

--- a/tests/e2e/keys.go
+++ b/tests/e2e/keys.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/go-bip39"
 )
 
+//nolint:unused // this is called during e2e tests
 func createMnemonic() (string, error) {
 	entropySeed, err := bip39.NewEntropy(256)
 	if err != nil {
@@ -22,6 +23,7 @@ func createMnemonic() (string, error) {
 	return mnemonic, nil
 }
 
+//nolint:unused,deadcode // this is called during e2e tests
 func createMemoryKey() (mnemonic string, info *keyring.Record, err error) {
 	mnemonic, err = createMnemonic()
 	if err != nil {
@@ -36,6 +38,7 @@ func createMemoryKey() (mnemonic string, info *keyring.Record, err error) {
 	return mnemonic, account, nil
 }
 
+//nolint:unused // this is called during e2e tests
 func createMemoryKeyFromMnemonic(mnemonic string) (*keyring.Record, error) {
 	kb, err := keyring.New("testnet", keyring.BackendMemory, "", nil, cdc)
 	if err != nil {

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -7,6 +7,7 @@ import (
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 )
 
+//nolint:unused // this is called during e2e tests
 func decodeTx(txBytes []byte) (*sdktx.Tx, error) {
 	var raw sdktx.TxRaw
 

--- a/tests/e2e/validator.go
+++ b/tests/e2e/validator.go
@@ -27,6 +27,7 @@ import (
 	gaia "github.com/cosmos/gaia/v8/app"
 )
 
+//nolint:unused
 type validator struct {
 	chain            *chain
 	index            int
@@ -39,19 +40,23 @@ type validator struct {
 	nodeKey          tmtypes.NodeKey
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) instanceName() string {
 	return fmt.Sprintf("%s%d", v.moniker, v.index)
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) configDir() string {
 	return fmt.Sprintf("%s/%s", v.chain.configDir(), v.instanceName())
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) createConfig() error {
 	p := path.Join(v.configDir(), "config")
 	return os.MkdirAll(p, 0o755)
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) init() error {
 	if err := v.createConfig(); err != nil {
 		return err
@@ -88,6 +93,7 @@ func (v *validator) init() error {
 	return nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) createNodeKey() error {
 	serverCtx := server.NewDefaultContext()
 	config := serverCtx.Config
@@ -104,6 +110,7 @@ func (v *validator) createNodeKey() error {
 	return nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) createConsensusKey() error {
 	serverCtx := server.NewDefaultContext()
 	config := serverCtx.Config
@@ -130,6 +137,7 @@ func (v *validator) createConsensusKey() error {
 	return nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) createKeyFromMnemonic(name, mnemonic string) error {
 	dir := v.configDir()
 	kb, err := keyring.New(keyringAppName, keyring.BackendTest, dir, nil, cdc)
@@ -165,6 +173,7 @@ func (v *validator) createKeyFromMnemonic(name, mnemonic string) error {
 	return nil
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) createKey(name string) error {
 	mnemonic, err := createMnemonic()
 	if err != nil {
@@ -174,6 +183,7 @@ func (v *validator) createKey(name string) error {
 	return v.createKeyFromMnemonic(name, mnemonic)
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) buildCreateValidatorMsg(amount sdk.Coin) (sdk.Msg, error) {
 	description := stakingtypes.NewDescription(v.moniker, "", "", "", "")
 	commissionRates := stakingtypes.CommissionRates{
@@ -206,6 +216,7 @@ func (v *validator) buildCreateValidatorMsg(amount sdk.Coin) (sdk.Msg, error) {
 	)
 }
 
+//nolint:unused // this is called during e2e tests
 func (v *validator) signMsg(msgs ...sdk.Msg) (*sdktx.Tx, error) {
 	txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 


### PR DESCRIPTION
Using the diff action to trigger the linters causes linter warnings and errors to be grandfathered in.  

* #1449 

This PR:

* changes the golang-ci lint config
* removes the diff action from golang-ci linter
* Passes all linters
* Fixes the cosmos hub golang-ci lint tools 

When reviewing:

Please look through the CI logs on the earlier commits.  Here's a summary:

* remove diff -> linters can now run
* reconfiguration 1 -> still broken
* reconfiguration 2 -> still broken
* use github action endorsed by golangci-lint authors -> linter runs
* fix grandfathered-in linter errors