### PR TITLE
Update sims.yml

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     steps:
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
             **/**.go
@@ -81,8 +81,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: actions/checkout@3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
             **/**.go
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
             **/**.go

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -61,7 +61,7 @@ jobs:
             go.mod
             go.sum
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3.0.0
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: actions/cache@v3.0.5

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3.0.0
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Install runsim
@@ -60,7 +60,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/checkout@2.4.0
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -78,10 +78,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     steps:
-      - uses: actions/setup-go@v3.0.0
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: actions/checkout@2.4.0
+      - uses: actions/checkout@3
       - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
@@ -103,7 +103,7 @@ jobs:
     needs: Build
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3.0.0
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: technote-space/get-diff-action@v6.0.1

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -60,7 +60,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/checkout@3
+      - uses: actions/checkout@2.4.0
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18
-      - uses: actions/checkout@3
+      - uses: actions/checkout@2.4.0
       - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -54,13 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     steps:
-      - uses: technote-space/get-diff-action@v5.0.2
+      - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
             **/**.go
             go.mod
             go.sum
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@3
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18
@@ -81,8 +81,8 @@ jobs:
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18
-      - uses: actions/checkout@v2.4.0
-      - uses: technote-space/get-diff-action@v5.0.2
+      - uses: actions/checkout@3
+      - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
             **/**.go
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.18
-      - uses: technote-space/get-diff-action@v5.0.2
+      - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
             **/**.go


### PR DESCRIPTION
Update versions used in sims action

* An alternative to this is removing the technote-space/get-diff-action@v6.0.1 action, which is used as a conditional trigger here.  The longest ci job is longer than any that depend on the conditional trigger.