### PR TITLE
Update release-sims.yml

### DIFF
--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-sims')"
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - run: |
           make build
 
@@ -62,11 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: newbuild
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.0.0
         with:
           go-version: 1.16
-      - uses: technote-space/get-diff-action@v5.0.2
+      - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
             **/**.go


### PR DESCRIPTION
Update release-sims github action

Alternatively, we could just not use 

technote-space/get-diff-action@v6.0.1

the longest ci job, codeql -- is one of the most valuable and takes longer than anything that we've got running conditionally