### PR TITLE
use distroless.dev/static base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ RUN apk add --no-cache $PACKAGES
 RUN CGO_ENABLED=0 make install
 
 # Add to a distroless container
-FROM gcr.io/distroless/cc:$IMG_TAG
+FROM distroless.dev/static:$IMG_TAG
 ARG IMG_TAG
 COPY --from=gaiad-builder /go/bin/gaiad /usr/local/bin/
 EXPOSE 26656 26657 1317 9090
+USER 0
 
 ENTRYPOINT ["gaiad", "start"]

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ endif
 .PHONY: run-tests $(TEST_TARGETS)
 
 docker-build-debug:
-	@docker build -t cosmos/gaiad-e2e --build-arg IMG_TAG=debug -f e2e.Dockerfile .
+	@docker build -t cosmos/gaiad-e2e -f e2e.Dockerfile .
 
 # TODO: Push this to the Cosmos Dockerhub so we don't have to keep building it
 # in CI.

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache $PACKAGES
 RUN CGO_ENABLED=0 make install
 
 # Add to a distroless container
-FROM gcr.io/distroless/cc:$IMG_TAG
+FROM distroless.dev/static:$IMG_TAG
 ARG IMG_TAG
 COPY --from=gaiad-builder /go/bin/gaiad /usr/local/bin/
 EXPOSE 26656 26657 1317 9090

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -245,7 +246,7 @@ func (s *IntegrationTestSuite) initGenesis(c *chain) {
 	bz, err = tmjson.MarshalIndent(genDoc, "", "  ")
 	s.Require().NoError(err)
 
-	// write the updated genesis file to each validator
+	// write the updated genesis file to each validator.
 	for _, val := range c.validators {
 		err = writeFile(filepath.Join(val.configDir(), "config", "genesis.json"), bz)
 		s.Require().NoError(err)
@@ -308,10 +309,12 @@ func (s *IntegrationTestSuite) runValidators(c *chain, portOffset int) {
 			Name:      val.instanceName(),
 			NetworkID: s.dkrNet.Network.ID,
 			Mounts: []string{
-				fmt.Sprintf("%s/:/root/.gaia", val.configDir()),
+				fmt.Sprintf("%s/:/home/nonroot/.gaia", val.configDir()),
 			},
 			Repository: "cosmos/gaiad-e2e",
 		}
+
+		s.Require().NoError(exec.Command("chmod", "-R", "0777", val.configDir()).Run())
 
 		// expose the first validator for debugging and communication
 		if val.index == 0 {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -126,7 +126,7 @@ func (s *IntegrationTestSuite) TestSendTokensFromNewGovAccount() {
 	proposalCounter++
 
 	s.T().Logf("Submitting Gov Proposal: Sending Tokens from Gov Module to Recipient")
-	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/root/.gaia/config/proposal_2.json")
+	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/home/nonroot/.gaia/config/proposal_2.json")
 	s.T().Logf("Depositing Gov Proposal: Sending Tokens from Gov Module to Recipient")
 	s.depositGovProposal(chainAAPIEndpoint, sender, proposalCounter)
 	s.T().Logf("Voting Gov Proposal: Sending Tokens from Gov Module to Recipient")
@@ -158,14 +158,14 @@ func (s *IntegrationTestSuite) TestGovSoftwareUpgrade() {
 	s.writeGovUpgradeSoftwareProposal(s.chainA, proposalHeight)
 
 	s.T().Logf("Submitting Gov Proposal: Software Upgrade")
-	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/root/.gaia/config/proposal_3.json")
+	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/home/nonroot/.gaia/config/proposal_3.json")
 	s.T().Logf("Depositing Gov Proposal: Software Upgrade")
 	s.depositGovProposal(chainAAPIEndpoint, sender, proposalCounter)
 	s.T().Logf("Weighted Voting Gov Proposal: Software Upgrade")
 	s.voteGovProposal(chainAAPIEndpoint, sender, proposalCounter, "yes=0.8,no=0.1,abstain=0.05,no_with_veto=0.05", true)
 
 	s.verifyChainHaltedAtUpgradeHeight(s.chainA, 0, proposalHeight)
-	s.T().Logf("Successfully halted chain at height %d", proposalHeight)
+	s.T().Logf("Successfully halted chain at  height %d", proposalHeight)
 
 	s.TearDownSuite()
 
@@ -201,14 +201,14 @@ func (s *IntegrationTestSuite) TestGovCancelSoftwareUpgrade() {
 	s.writeGovUpgradeSoftwareProposal(s.chainA, proposalHeight)
 
 	s.T().Logf("Submitting Gov Proposal: Software Upgrade")
-	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/root/.gaia/config/proposal_3.json")
+	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/home/nonroot/.gaia/config/proposal_3.json")
 	s.depositGovProposal(chainAAPIEndpoint, sender, proposalCounter)
 	s.voteGovProposal(chainAAPIEndpoint, sender, proposalCounter, "yes", false)
 
 	proposalCounter++
 
 	s.T().Logf("Submitting Gov Proposal: Cancel Software Upgrade")
-	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/root/.gaia/config/proposal_4.json")
+	s.submitNewGovProposal(chainAAPIEndpoint, sender, proposalCounter, "/home/nonroot/.gaia/config/proposal_4.json")
 	s.depositGovProposal(chainAAPIEndpoint, sender, proposalCounter)
 	s.voteGovProposal(chainAAPIEndpoint, sender, proposalCounter, "yes", false)
 
@@ -247,7 +247,7 @@ func (s *IntegrationTestSuite) fundCommunityPool(chainAAPIEndpoint, sender strin
 
 func (s *IntegrationTestSuite) submitLegacyProposalFundGovAccount(chainAAPIEndpoint, sender string, proposalId int) {
 	s.Run("submit_legacy_community_spend_proposal_to_fund_gov_acct", func() {
-		s.execGovSubmitLegacyGovProposal(s.chainA, 0, chainAAPIEndpoint, sender, "/root/.gaia/config/proposal.json", fees.String(), "community-pool-spend")
+		s.execGovSubmitLegacyGovProposal(s.chainA, 0, chainAAPIEndpoint, sender, "/home/nonroot/.gaia/config/proposal.json", fees.String(), "community-pool-spend")
 
 		s.Require().Eventually(
 			func() bool {

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -28,7 +28,7 @@ func (s *IntegrationTestSuite) connectIBCChains() {
 		AttachStdout: true,
 		AttachStderr: true,
 		Container:    s.hermesResource.Container.ID,
-		User:         "root",
+		User:         "nonroot",
 		Cmd: []string{
 			"hermes",
 			"create",
@@ -77,7 +77,7 @@ func (s *IntegrationTestSuite) sendMsgSend(c *chain, valIdx int, from, to, amt, 
 		AttachStdout: true,
 		AttachStderr: true,
 		Container:    s.valResources[c.id][valIdx].Container.ID,
-		User:         "root",
+		User:         "nonroot",
 		Cmd: []string{
 			"gaiad",
 			"tx",
@@ -137,7 +137,7 @@ func (s *IntegrationTestSuite) sendIBC(srcChainID, dstChainID, recipient string,
 		AttachStdout: true,
 		AttachStderr: true,
 		Container:    s.hermesResource.Container.ID,
-		User:         "root",
+		User:         "nonroot",
 		Cmd: []string{
 			"hermes",
 			"tx",
@@ -337,7 +337,7 @@ func (s *IntegrationTestSuite) executeGaiaTxCommand(ctx context.Context, c *chai
 				AttachStdout: true,
 				AttachStderr: true,
 				Container:    s.valResources[c.id][valIdx].Container.ID,
-				User:         "root",
+				User:         "nonroot",
 				Cmd:          gaiaCommand,
 			})
 			s.Require().NoError(err)
@@ -426,7 +426,7 @@ func (s *IntegrationTestSuite) getLatestBlockHeight(c *chain, valIdx int) int {
 				AttachStdout: true,
 				AttachStderr: true,
 				Container:    s.valResources[c.id][valIdx].Container.ID,
-				User:         "root",
+				User:         "nonroot",
 				Cmd:          []string{"gaiad", "status"},
 			})
 			s.Require().NoError(err)

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -28,7 +28,7 @@ func (s *IntegrationTestSuite) connectIBCChains() {
 		AttachStdout: true,
 		AttachStderr: true,
 		Container:    s.hermesResource.Container.ID,
-		User:         "nonroot",
+		User:         "root",
 		Cmd: []string{
 			"hermes",
 			"create",
@@ -137,7 +137,7 @@ func (s *IntegrationTestSuite) sendIBC(srcChainID, dstChainID, recipient string,
 		AttachStdout: true,
 		AttachStderr: true,
 		Container:    s.hermesResource.Container.ID,
-		User:         "nonroot",
+		User:         "root",
 		Cmd: []string{
 			"hermes",
 			"tx",


### PR DESCRIPTION
This change is a redo of https://github.com/cosmos/gaia/pull/1628 with fixes for the failed tests in https://github.com/cosmos/gaia/pull/1625 . Specifically, the hermes container still runs as `root`, so commands need to be sent to it as `root` rather than `nonroot`.

Updates https://github.com/cosmos/gaia/issues/1621

/cc @okwme @odeke-em
