### PR TITLE
fix: add icacontrollertypes.StoreKey to StoreUpgrades

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -766,7 +766,7 @@ func NewGaiaApp(
 
 	if upgradeInfo.Name == upgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{icahosttypes.StoreKey},
+			Added: []string{icacontrollertypes.StoreKey, icahosttypes.StoreKey},
 		}
 
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades


### PR DESCRIPTION
Upgrading a network from gaia 6 to gaia 7 may result in a panic for nodes that have custom pruning settings enabled.
This fix adds the missing `icacontrollertypes.StoreKey` store in StoreUpgrades to protect against this case.

Ref: https://github.com/cosmos/ibc-go/issues/1088

example error on a network upgrading from 6 to 7:
```
ERR CONSENSUS FAILURE!!! err="cannot delete latest saved version (5)" module=consensus stack="goroutine 355 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x65
github.com/tendermint/tendermint/consensus.(*State).receiveRoutine.func2()
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:727 +0x4c
panic({0x19249e0, 0xc00464b0f8})
	runtime/panic.go:838 +0x207
github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).pruneStores(0xc001200580)
	github.com/cosmos/cosmos-sdk@v0.45.4/store/rootmulti/store.go:447 +0x1b6
github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).Commit(0xc001200580)
	github.com/cosmos/cosmos-sdk@v0.45.4/store/rootmulti/store.go:421 +0x175
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Commit(0xc00050c4e0)
	github.com/cosmos/cosmos-sdk@v0.45.4/baseapp/abci.go:308 +0x1e9
github.com/tendermint/tendermint/abci/client.(*localClient).CommitSync(0xc0010bcde0)
	github.com/tendermint/tendermint@v0.34.19/abci/client/local_client.go:264 +0xb6
github.com/tendermint/tendermint/proxy.(*appConnConsensus).CommitSync(0xc0028d2488?)
	github.com/tendermint/tendermint@v0.34.19/proxy/app_conn.go:93 +0x22
github.com/tendermint/tendermint/state.(*BlockExecutor).Commit(_, {{{0xb, 0x0}, {0xc00126f7a0, 0x8}}, {0xc002dc2210, 0x11}, 0x1, 0xad52, {{0xc004304f60, ...}, ...}, ...}, ...)
	github.com/tendermint/tendermint@v0.34.19/state/execution.go:228 +0x269
github.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x0}, {0xc00126f7a0, 0x8}}, {0xc002dc2210, 0x11}, 0x1, 0xad52, {{0xc004304f60, ...}, ...}, ...}, ...)
	github.com/tendermint/tendermint@v0.34.19/state/execution.go:180 +0x6ee
github.com/tendermint/tendermint/consensus.(*State).finalizeCommit(0xc00376a000, 0xad52)
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:1655 +0x9fd
github.com/tendermint/tendermint/consensus.(*State).tryFinalizeCommit(0xc00376a000, 0xad52)
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:1564 +0x305
github.com/tendermint/tendermint/consensus.(*State).enterCommit.func1()
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:1499 +0x87
github.com/tendermint/tendermint/consensus.(*State).enterCommit(0xc00376a000, 0xad52, 0x0)
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:1537 +0xbea
github.com/tendermint/tendermint/consensus.(*State).addVote(0xc00376a000, 0xc003cdcfa0, {0xc001829110, 0x28})
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:2151 +0xb7c
github.com/tendermint/tendermint/consensus.(*State).tryAddVote(0xc00376a000, 0xc003cdcfa0, {0xc001829110?, 0xc003c8ee00?})
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:1949 +0x2c
github.com/tendermint/tendermint/consensus.(*State).handleMsg(0xc00376a000, {{0x2407860?, 0xc000527dc0?}, {0xc001829110?, 0x0?}})
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:856 +0x44b
github.com/tendermint/tendermint/consensus.(*State).receiveRoutine(0xc00376a000, 0x0)
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:763 +0x419
created by github.com/tendermint/tendermint/consensus.(*State).OnStart
	github.com/tendermint/tendermint@v0.34.19/consensus/state.go:379 +0x12d
```