### PR TITLE
test: Staking module e2e tests

### DIFF
--- a/tests/e2e/e2e_cli_util.go
+++ b/tests/e2e/e2e_cli_util.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"io"
 	"net/http"
 	"strings"
@@ -104,24 +105,23 @@ func queryGaiaDenomBalance(endpoint, addr, denom string) (sdk.Coin, error) {
 }
 
 func queryGovProposal(endpoint string, proposalID int) (govv1beta1.QueryProposalResponse, error) {
-	var emptyProp govv1beta1.QueryProposalResponse
+	var govProposalResp govv1beta1.QueryProposalResponse
 
 	path := fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals/%d", endpoint, proposalID)
 
 	resp, err := http.Get(path) //nolint:gosec // this is only used during tests
 	if err != nil {
-		return emptyProp, fmt.Errorf("failed to execute HTTP request: %w", err)
+		return govProposalResp, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return emptyProp, err
+		return govProposalResp, err
 	}
 
-	var govProposalResp govv1beta1.QueryProposalResponse
 	if err := cdc.UnmarshalJSON(body, &govProposalResp); err != nil {
-		return emptyProp, err
+		return govProposalResp, err
 	}
 
 	return govProposalResp, nil
@@ -145,4 +145,25 @@ func queryGlobalFees(endpoint string) (amt sdk.DecCoins, err error) {
 	}
 
 	return fees.MinimumGasPrices, nil
+}
+
+func queryDelegation(endpoint string, validatorAddr string, delegatorAddr string) (staketypes.QueryDelegationResponse, error) {
+	var delegationRes staketypes.QueryDelegationResponse
+
+	resp, err := http.Get(fmt.Sprintf("%s/cosmos/staking/v1beta1/validators/%s/delegations/%s", endpoint, validatorAddr, delegatorAddr)) //nolint:gosec // this is only used during tests
+	if err != nil {
+		return delegationRes, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return delegationRes, err
+	}
+
+	if err := cdc.UnmarshalJSON(body, &delegationRes); err != nil {
+		return delegationRes, err
+	}
+
+	return delegationRes, nil
 }

--- a/tests/e2e/e2e_cli_util.go
+++ b/tests/e2e/e2e_cli_util.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"io"
 	"net/http"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	globalfee "github.com/cosmos/gaia/v8/x/globalfee/types"
 )

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -55,7 +55,7 @@ const (
 
 var (
 	stakeAmount       = math.NewInt(100000000000)
-	stakeAmountCoin   = sdk.NewCoin("stake", stakeAmount)
+	stakeAmountCoin   = sdk.NewCoin(uatomDenom, stakeAmount)
 	tokenAmount       = sdk.NewCoin(uatomDenom, math.NewInt(3300000000)) // 3,300uatom
 	fees              = sdk.NewCoin(uatomDenom, math.NewInt(330000))     // 0.33uatom
 	depositAmount     = sdk.NewCoin(uatomDenom, math.NewInt(10000000))   // 10uatom

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -54,8 +54,8 @@ const (
 )
 
 var (
-	stakeAmount       = math.NewInt(100000000000)
-	stakeAmountCoin   = sdk.NewCoin(uatomDenom, stakeAmount)
+	stakingAmount     = math.NewInt(100000000000)
+	stakingAmountCoin = sdk.NewCoin(uatomDenom, stakingAmount)
 	tokenAmount       = sdk.NewCoin(uatomDenom, math.NewInt(3300000000)) // 3,300uatom
 	fees              = sdk.NewCoin(uatomDenom, math.NewInt(330000))     // 0.33uatom
 	depositAmount     = sdk.NewCoin(uatomDenom, math.NewInt(10000000))   // 10uatom
@@ -214,7 +214,7 @@ func (s *IntegrationTestSuite) initNodes(c *chain) {
 		address, err := val.keyInfo.GetAddress()
 		s.Require().NoError(err)
 		s.Require().NoError(
-			modifyGenesis(val0ConfigDir, "", initBalanceStr, address, initialGlobalFeeAmt+uatomDenom),
+			modifyGenesis(val0ConfigDir, "", initBalanceStr, address, initialGlobalFeeAmt+uatomDenom, uatomDenom),
 		)
 	}
 
@@ -266,7 +266,7 @@ func (s *IntegrationTestSuite) initGenesis(c *chain) {
 	// generate genesis txs
 	genTxs := make([]json.RawMessage, len(c.validators))
 	for i, val := range c.validators {
-		createValmsg, err := val.buildCreateValidatorMsg(stakeAmountCoin)
+		createValmsg, err := val.buildCreateValidatorMsg(stakingAmountCoin)
 		s.Require().NoError(err)
 		signedTx, err := val.signMsg(createValmsg)
 

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -1,0 +1,64 @@
+package e2e
+
+import (
+	"cosmossdk.io/math"
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"time"
+)
+
+func (s *IntegrationTestSuite) testStaking() {
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
+	seedAmount := sdk.NewCoin(uatomDenom, math.NewInt(1000000000)) // 2,200uatom
+	delegationAmount := math.NewInt(500000000)
+	delegation := sdk.NewCoin(uatomDenom, delegationAmount) // 2,200uatom
+
+	validatorA := s.chainA.validators[0]
+	validatorB := s.chainA.validators[1]
+	sender, err := validatorA.keyInfo.GetAddress()
+	s.NoError(err)
+	validatorBAddr, err := validatorB.keyInfo.GetAddress()
+	s.NoError(err)
+
+	valOperA := sdk.ValAddress(sender)
+	valOperB := sdk.ValAddress(validatorBAddr)
+
+	alice := s.executeGKeysAddCommand(s.chainA, 0, "alice", dataDirectoryHome)
+	delegationFees := sdk.NewCoin(uatomDenom, math.NewInt(3))
+
+	// Fund Alice
+	s.sendMsgSend(s.chainA, 0, sender.String(), alice, seedAmount.String(), fees.String(), false)
+	s.verifyBalanceChange(chainAAPIEndpoint, seedAmount, alice)
+
+	// Alice delegate uatom to Validator A
+	s.executeDelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), alice, dataDirectoryHome, delegationFees.String())
+
+	// Validate delegation successful
+	s.Require().Eventually(
+		func() bool {
+			res, err := queryDelegation(chainAAPIEndpoint, valOperA.String(), alice)
+			amt := res.GetDelegationResponse().GetDelegation().GetShares()
+			s.Require().NoError(err)
+
+			return amt.Equal(sdk.NewDecFromInt(delegationAmount))
+		},
+		20*time.Second,
+		5*time.Second,
+	)
+
+	// Alice redelegate uatom from Validator A to Validator B
+	s.executeRedelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), valOperB.String(), alice, dataDirectoryHome, delegationFees.String())
+
+	// Validate redelegation successful
+	s.Require().Eventually(
+		func() bool {
+			res, err := queryDelegation(chainAAPIEndpoint, valOperB.String(), alice)
+			amt := res.GetDelegationResponse().GetDelegation().GetShares()
+			s.Require().NoError(err)
+
+			return amt.Equal(sdk.NewDecFromInt(delegationAmount))
+		},
+		20*time.Second,
+		5*time.Second,
+	)
+}

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -12,6 +12,7 @@ func (s *IntegrationTestSuite) testStaking() {
 	seedAmount := sdk.NewCoin(uatomDenom, math.NewInt(1000000000)) // 2,200uatom
 	delegationAmount := math.NewInt(500000000)
 	delegation := sdk.NewCoin(uatomDenom, delegationAmount) // 2,200uatom
+	home := "/home/nonroot/.gaia"
 
 	validatorA := s.chainA.validators[0]
 	validatorB := s.chainA.validators[1]
@@ -23,7 +24,7 @@ func (s *IntegrationTestSuite) testStaking() {
 	valOperA := sdk.ValAddress(sender)
 	valOperB := sdk.ValAddress(validatorBAddr)
 
-	alice := s.executeGKeysAddCommand(s.chainA, 0, "alice", dataDirectoryHome)
+	alice := s.executeGKeysAddCommand(s.chainA, 0, "alice", home)
 	// up the amount
 	delegationFees := sdk.NewCoin(uatomDenom, math.NewInt(10))
 
@@ -31,8 +32,9 @@ func (s *IntegrationTestSuite) testStaking() {
 	s.sendMsgSend(s.chainA, 0, sender.String(), alice, seedAmount.String(), fees.String(), false)
 	s.verifyBalanceChange(chainAAPIEndpoint, seedAmount, alice)
 
+	s.debugConfig(s.chainA, 0, home)
 	// Alice delegate uatom to Validator A
-	s.executeDelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), alice, dataDirectoryHome, delegationFees.String())
+	s.executeDelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), alice, home, delegationFees.String())
 
 	// Validate delegation successful
 	s.Require().Eventually(
@@ -48,7 +50,7 @@ func (s *IntegrationTestSuite) testStaking() {
 	)
 
 	// Alice redelegate uatom from Validator A to Validator B
-	s.executeRedelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), valOperB.String(), alice, dataDirectoryHome, delegationFees.String())
+	s.executeRedelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), valOperB.String(), alice, home, delegationFees.String())
 
 	// Validate redelegation successful
 	s.Require().Eventually(

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -32,7 +32,6 @@ func (s *IntegrationTestSuite) testStaking() {
 	s.sendMsgSend(s.chainA, 0, sender.String(), alice, seedAmount.String(), fees.String(), false)
 	s.verifyBalanceChange(chainAAPIEndpoint, seedAmount, alice)
 
-	s.debugConfig(s.chainA, 0, home)
 	// Alice delegate uatom to Validator A
 	s.executeDelegate(s.chainA, 0, chainAAPIEndpoint, delegation.String(), valOperA.String(), alice, home, delegationFees.String())
 

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -24,7 +24,8 @@ func (s *IntegrationTestSuite) testStaking() {
 	valOperB := sdk.ValAddress(validatorBAddr)
 
 	alice := s.executeGKeysAddCommand(s.chainA, 0, "alice", dataDirectoryHome)
-	delegationFees := sdk.NewCoin(uatomDenom, math.NewInt(3))
+	// up the amount
+	delegationFees := sdk.NewCoin(uatomDenom, math.NewInt(10))
 
 	// Fund Alice
 	s.sendMsgSend(s.chainA, 0, sender.String(), alice, seedAmount.String(), fees.String(), false)

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -9,9 +9,9 @@ import (
 
 func (s *IntegrationTestSuite) testStaking() {
 	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
-	seedAmount := sdk.NewCoin(uatomDenom, math.NewInt(1000000000)) // 2,200uatom
+	seedAmount := sdk.NewCoin(uatomDenom, math.NewInt(1000000000)) // 1,000 atom
 	delegationAmount := math.NewInt(500000000)
-	delegation := sdk.NewCoin(uatomDenom, delegationAmount) // 2,200uatom
+	delegation := sdk.NewCoin(uatomDenom, delegationAmount) // 500 atom
 	home := "/home/nonroot/.gaia"
 
 	validatorA := s.chainA.validators[0]
@@ -25,7 +25,6 @@ func (s *IntegrationTestSuite) testStaking() {
 	valOperB := sdk.ValAddress(validatorBAddr)
 
 	alice := s.executeGKeysAddCommand(s.chainA, 0, "alice", home)
-	// up the amount
 	delegationFees := sdk.NewCoin(uatomDenom, math.NewInt(10))
 
 	// Fund Alice

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -743,3 +743,6 @@ func (s *IntegrationTestSuite) TestByPassMinFeeWithdrawReward() {
 }
 
 // todo add fee test with wrong denom order
+func (s *IntegrationTestSuite) TestStaking() {
+	s.testStaking()
+}

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -394,7 +394,7 @@ func (s *IntegrationTestSuite) executeGaiaTxCommand(ctx context.Context, c *chai
 				AttachStdout: true,
 				AttachStderr: true,
 				Container:    s.valResources[c.id][valIdx].Container.ID,
-				User:         "nonroot",
+				User:         "root",
 				Cmd:          gaiaCommand,
 			})
 			s.Require().NoError(err)

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -394,7 +394,7 @@ func (s *IntegrationTestSuite) executeGaiaTxCommand(ctx context.Context, c *chai
 				AttachStdout: true,
 				AttachStderr: true,
 				Container:    s.valResources[c.id][valIdx].Container.ID,
-				User:         "root",
+				User:         "nonroot",
 				Cmd:          gaiaCommand,
 			})
 			s.Require().NoError(err)

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -406,12 +406,10 @@ func (s *IntegrationTestSuite) executeGaiaTxCommand(ctx context.Context, c *chai
 				ErrorStream:  &errBuf,
 			})
 
-			s.T().Logf("stdOut: %s", outBuf.String())
-			s.T().Logf("stdErr: %s", errBuf.String())
-
 			s.Require().NoError(err)
 			s.Require().NoError(cdc.UnmarshalJSON(outBuf.Bytes(), &txResp))
-			return strings.Contains(txResp.String(), "code: 0")
+
+			return strings.Contains(txResp.String(), "code: 0") || txResp.Code == uint32(0)
 		},
 		10*time.Second,
 		time.Second,
@@ -817,7 +815,23 @@ func (s *IntegrationTestSuite) queryGroupProposalByGroupPolicy(endpoint string, 
 	return res, nil
 }
 
-func (s *IntegrationTestSuite) executeGaiaKeysAddCommand(ctx context.Context, c *chain, valIdx int, name string) string {
+func (s *IntegrationTestSuite) verifyBalanceChange(endpoint string, expectedAmount sdk.Coin, recipientAddress string) {
+	s.Require().Eventually(
+		func() bool {
+			afterAtomBalance, err := getSpecificBalance(endpoint, recipientAddress, uatomDenom)
+			s.Require().NoError(err)
+
+			return afterAtomBalance.IsEqual(expectedAmount)
+		},
+		20*time.Second,
+		5*time.Second,
+	)
+}
+
+func (s *IntegrationTestSuite) executeGKeysAddCommand(c *chain, valIdx int, name string, home string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
 	var (
 		outBuf     bytes.Buffer
 		errBuf     bytes.Buffer
@@ -829,6 +843,7 @@ func (s *IntegrationTestSuite) executeGaiaKeysAddCommand(ctx context.Context, c 
 		"keys",
 		"add",
 		name,
+		fmt.Sprintf("--%s=%s", flags.FlagHome, home),
 		"--keyring-backend=test",
 		"--output=json",
 	}
@@ -862,4 +877,103 @@ func (s *IntegrationTestSuite) executeGaiaKeysAddCommand(ctx context.Context, c 
 	)
 
 	return addrRecord.Address
+}
+
+func (s *IntegrationTestSuite) executeKeysList(c *chain, valIdx int, home string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var (
+		outBuf bytes.Buffer
+		errBuf bytes.Buffer
+	)
+
+	gaiaCommand := []string{
+		"gaiad",
+		"keys",
+		"list",
+		"--keyring-backend=test",
+		fmt.Sprintf("--%s=%s", flags.FlagHome, home),
+		"--output=json",
+	}
+
+	s.Require().Eventually(
+		func() bool {
+			exec, err := s.dkrPool.Client.CreateExec(docker.CreateExecOptions{
+				Context:      ctx,
+				AttachStdout: true,
+				AttachStderr: true,
+				Container:    s.valResources[c.id][valIdx].Container.ID,
+				User:         "root",
+				Cmd:          gaiaCommand,
+			})
+			s.Require().NoError(err)
+
+			err = s.dkrPool.Client.StartExec(exec.ID, docker.StartExecOptions{
+				Context:      ctx,
+				Detach:       false,
+				OutputStream: &outBuf,
+				ErrorStream:  &errBuf,
+			})
+			s.Require().NoError(err)
+			return true
+		},
+		10*time.Second,
+		time.Second,
+		"Returned an error; stdout: %s, stderr: %s", outBuf.String(), errBuf.String(),
+	)
+}
+
+func (s *IntegrationTestSuite) executeDelegate(c *chain, valIdx int, endpoint string, amount string, valOperAddress string, delegatorAddr string, home string, delegateFees string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	s.T().Logf("Executing gaiad tx staking delegate %s", c.id)
+
+	gaiaCommand := []string{
+		"gaiad",
+		"tx",
+		"staking",
+		"delegate",
+		valOperAddress,
+		amount,
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, delegatorAddr),
+		fmt.Sprintf("--%s=%s", flags.FlagChainID, c.id),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, delegateFees),
+		"--keyring-backend=test",
+		fmt.Sprintf("--%s=%s", flags.FlagHome, home),
+		"--output=json",
+		"-y",
+	}
+
+	s.executeGaiaTxCommand(ctx, c, gaiaCommand, valIdx, endpoint)
+	s.T().Logf("%s successfully delegated %s to %s", delegatorAddr, amount, valOperAddress)
+}
+
+func (s *IntegrationTestSuite) executeRedelegate(c *chain, valIdx int, endpoint string, amount string, originalValOperAddress string, newValOperAddress string, delegatorAddr string, home string, delegateFees string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	s.T().Logf("Executing gaiad tx staking redelegate %s", c.id)
+
+	gaiaCommand := []string{
+		"gaiad",
+		"tx",
+		"staking",
+		"redelegate",
+		originalValOperAddress,
+		newValOperAddress,
+		amount,
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, delegatorAddr),
+		fmt.Sprintf("--%s=%s", flags.FlagChainID, c.id),
+		fmt.Sprintf("--%s=%s", flags.FlagGas, "auto"),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, delegateFees),
+		"--keyring-backend=test",
+		fmt.Sprintf("--%s=%s", flags.FlagHome, home),
+		"--output=json",
+		"-y",
+	}
+
+	s.executeGaiaTxCommand(ctx, c, gaiaCommand, valIdx, endpoint)
+	s.T().Logf("%s successfully redelegated %s from %s to %s", delegatorAddr, amount, originalValOperAddress, newValOperAddress)
 }

--- a/tests/e2e/e2e_util_test.go
+++ b/tests/e2e/e2e_util_test.go
@@ -406,6 +406,9 @@ func (s *IntegrationTestSuite) executeGaiaTxCommand(ctx context.Context, c *chai
 				ErrorStream:  &errBuf,
 			})
 
+			s.T().Logf("Outbuff: %s", outBuf.String())
+			s.T().Logf("Errbuff: %s", errBuf.String())
+
 			s.Require().NoError(err)
 			s.Require().NoError(cdc.UnmarshalJSON(outBuf.Bytes(), &txResp))
 
@@ -939,6 +942,7 @@ func (s *IntegrationTestSuite) executeDelegate(c *chain, valIdx int, endpoint st
 		amount,
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, delegatorAddr),
 		fmt.Sprintf("--%s=%s", flags.FlagChainID, c.id),
+		fmt.Sprintf("--%s=%s", flags.FlagGas, "auto"),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, delegateFees),
 		"--keyring-backend=test",
 		fmt.Sprintf("--%s=%s", flags.FlagHome, home),

--- a/tests/e2e/genesis.go
+++ b/tests/e2e/genesis.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"os"
 	"time"
 
@@ -117,6 +118,14 @@ func modifyGenesis(path, moniker, amountStr string, accAddr sdk.AccAddress, glob
 		return fmt.Errorf("failed to marshal global fee genesis state: %w", err)
 	}
 	appState[globfeetypes.ModuleName] = globfeeStateBz
+
+	stakingGenState := staketypes.GetGenesisStateFromAppState(cdc, appState)
+	stakingGenState.Params.BondDenom = "uatom"
+	stakingGenStateBz, err := cdc.MarshalJSON(stakingGenState)
+	if err != nil {
+		fmt.Errorf("Failed to marshal staking genesis state: %w", err)
+	}
+	appState[staketypes.ModuleName] = stakingGenStateBz
 
 	// Refactor to separate method
 	amnt := math.NewInt(10000)

--- a/tests/e2e/genesis.go
+++ b/tests/e2e/genesis.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"os"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	globfeetypes "github.com/cosmos/gaia/v8/x/globalfee/types"

--- a/tests/e2e/genesis.go
+++ b/tests/e2e/genesis.go
@@ -45,7 +45,7 @@ func getGenDoc(path string) (*tmtypes.GenesisDoc, error) {
 	return doc, nil
 }
 
-func modifyGenesis(path, moniker, amountStr string, accAddr sdk.AccAddress, globfees string) error {
+func modifyGenesis(path, moniker, amountStr string, accAddr sdk.AccAddress, globfees string, denom string) error {
 	serverCtx := server.NewDefaultContext()
 	config := serverCtx.Config
 
@@ -120,7 +120,7 @@ func modifyGenesis(path, moniker, amountStr string, accAddr sdk.AccAddress, glob
 	appState[globfeetypes.ModuleName] = globfeeStateBz
 
 	stakingGenState := staketypes.GetGenesisStateFromAppState(cdc, appState)
-	stakingGenState.Params.BondDenom = "uatom"
+	stakingGenState.Params.BondDenom = denom
 	stakingGenStateBz, err := cdc.MarshalJSON(stakingGenState)
 	if err != nil {
 		fmt.Errorf("Failed to marshal staking genesis state: %w", err)
@@ -133,7 +133,7 @@ func modifyGenesis(path, moniker, amountStr string, accAddr sdk.AccAddress, glob
 	threshold, _ := sdk.NewDecFromStr("0.000000000000000001")
 
 	govState := govv1beta1.NewGenesisState(1,
-		govv1beta1.NewDepositParams(sdk.NewCoins(sdk.NewCoin("uatom", amnt)), 10*time.Minute),
+		govv1beta1.NewDepositParams(sdk.NewCoins(sdk.NewCoin(denom, amnt)), 10*time.Minute),
 		govv1beta1.NewVotingParams(15*time.Second),
 		govv1beta1.NewTallyParams(quorum, threshold, govv1beta1.DefaultVetoThreshold),
 	)


### PR DESCRIPTION
This PR fulfills basic test commitment for #1630 and introduces a new suite of tests for the staking module.

CLI commands tested
- `keys`
  - `add` Add new key
- `tx staking`
  - `delegate` Delegate staked tokens to a validator
  - `redelegate` Redelegate previously staked tokens to a new validator


REST endpoints tested
- [Delegation](https://docs.cosmos.network/v0.46/modules/staking/09_client.html#delegation-3) `/cosmos/staking/v1beta1/validators/{validatorAddresess}/delegations/{delegatorAddress}` 

User Flows
- A user wants to delegate tokens to a known validator
- A user wants to redelegate tokens that are staked to a new validator

This PR also includes a few refactors related to minor formatting in the group tests.