### PR TITLE
feature: implement ante handle for min commission

### DIFF
--- a/ante/ante.go
+++ b/ante/ante.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -16,6 +17,7 @@ type HandlerOptions struct {
 	IBCkeeper            *ibckeeper.Keeper
 	BypassMinFeeMsgTypes []string
 	GlobalFeeSubspace    paramtypes.Subspace
+	Cdc                  codec.BinaryCodec
 }
 
 func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
@@ -48,6 +50,7 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewValidateMemoDecorator(opts.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(opts.AccountKeeper),
 		NewBypassMinFeeDecorator(opts.BypassMinFeeMsgTypes, opts.GlobalFeeSubspace),
+		NewMinCommissionDecorator(opts.Cdc),
 		// if opts.TxFeeCheck is nil,  it is the default fee check
 		ante.NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, opts.TxFeeChecker),
 		ante.NewSetPubKeyDecorator(opts.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators

--- a/ante/min_commission.go
+++ b/ante/min_commission.go
@@ -1,0 +1,80 @@
+package ante
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+type MinCommissionDecorator struct {
+	cdc codec.BinaryCodec
+}
+
+func NewMinCommissionDecorator(cdc codec.BinaryCodec) MinCommissionDecorator {
+	return MinCommissionDecorator{cdc}
+}
+
+func (min MinCommissionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	msgs := tx.GetMsgs()
+	minCommissionRate := sdk.NewDecWithPrec(5, 2)
+
+	validMsg := func(m sdk.Msg) error {
+		switch msg := m.(type) {
+		case *stakingtypes.MsgCreateValidator:
+			// prevent new validators joining the set with
+			// commission set below 5%
+			c := msg.Commission
+			if c.Rate.LT(minCommissionRate) {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "commission can't be lower than 5%")
+			}
+		case *stakingtypes.MsgEditValidator:
+			// if commission rate is nil, it means only
+			// other fields are affected - skip
+			if msg.CommissionRate == nil {
+				break
+			}
+			if msg.CommissionRate.LT(minCommissionRate) {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "commission can't be lower than 5%")
+			}
+		}
+
+		return nil
+	}
+
+	validAuthz := func(execMsg *authz.MsgExec) error {
+		for _, v := range execMsg.Msgs {
+			var innerMsg sdk.Msg
+			err := min.cdc.UnpackAny(v, &innerMsg)
+			if err != nil {
+				return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "cannot unmarshal authz exec msgs")
+			}
+
+			err = validMsg(innerMsg)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	for _, m := range msgs {
+		if msg, ok := m.(*authz.MsgExec); ok {
+			if err := validAuthz(msg); err != nil {
+				return ctx, err
+			}
+			continue
+		}
+
+		// validate normal msgs
+		err = validMsg(m)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}


### PR DESCRIPTION
If proposal 76 passes, validator min commission should be enforced onchain.

Right now MsgEditValidator and MsgCreateValidator allow any commission value, we should check that c.Rate is above the amount decided by governance.

-- 

Need to add something like this to the next upgrade handler
```golang
// force an update of validator min commission
validators := app.StakingKeeper.GetAllValidators(ctx)
		
minCommissionRate := sdk.NewDecWithPrec(5, 2)
for _, v := range validators {
    if v.Commission.Rate.LT(minCommissionRate) {
        if v.Commission.MaxRate.LT(minCommissionRate) {
            v.Commission.MaxRate = minCommissionRate
        }

    v.Commission.Rate = minCommissionRate
    v.Commission.UpdateTime = ctx.BlockHeader().Time

    // call the before-modification hook since we're about to update the commission
    app.StakingKeeper.BeforeValidatorModified(ctx, v.GetOperator())

    app.StakingKeeper.SetValidator(ctx, v)
    }
}
```


Closes #1697 


Original code by giansalex, Osmosis and Juno teams