### PR TITLE
Potential memory exposure in dns-packet

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4778,9 +4778,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "node_modules/dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "dependencies": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -17207,9 +17207,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "requires": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"


### PR DESCRIPTION
## Describe the bugs: 🐛
Remote memory exposure vulnerability was found in nodejs dns-packet library. The buffers (created with `allocUnsafe`) are not always filled before forming the network packets and an attacker can use this vulnerability to potentially get access to internal application memory over non encrypted networks when querying crafted invalid domain names.

**CVE-2021-23386**
`CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L`
GHSA-3wcq-x3mq-6r9p
