### PR TITLE
Regular Expression Denial of Service in postcss

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8646,12 +8646,12 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dependencies": {
         "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
+        "source-map": "^0.6.1"
         "supports-color": "^6.1.0"
       },
       "engines": {
@@ -20243,9 +20243,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",


### PR DESCRIPTION
## Describe the bugs: 🐛
A regular expression denial of service (ReDoS) vulnerability was found in the npm library postcss. When parsing a supplied CSS string, if it contains an unexpected value then as the supplied CSS grows in length it will take an ever increasing amount of time to process. An attacker can use this vulnerability to potentially craft a malicious a long CSS value to process resulting in a denial of service.

**CVE-2021-23368**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`
GHSA-hwj9-h5mp-3pm3
