### PR TITLE
fix: remove upgradeKeeper duplicate initialization

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -456,15 +456,6 @@ func NewGaiaApp(
 		govConfig,
 	)
 
-	app.UpgradeKeeper = upgradekeeper.NewKeeper(
-		skipUpgradeHeights,
-		keys[upgradetypes.StoreKey],
-		appCodec,
-		homePath,
-		app.BaseApp,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
 	app.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
 		keys[ibctransfertypes.StoreKey],


### PR DESCRIPTION
upgrade keeper is initialised twice in app.go
https://github.com/cosmos/gaia/compare/main...puneet2019:gaia:puneet/upgradekeeperduplication?expand=1#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7L415-L422

https://github.com/cosmos/gaia/blob/main/app/app.go#L415-L422
AND https://github.com/cosmos/gaia/blob/main/app/app.go#L459-L466
removing the usage that comes after gov.handler (2nd one)
