### PR TITLE
bug(app config): fix the wrong `bypass-min-fee-msg-types` key parse from the app config file

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -676,9 +676,8 @@ func NewGaiaApp(
 	app.MountTransientStores(tkeys)
 	app.MountMemoryStores(memKeys)
 
-	appStateSync := cast.ToStringMap(appOpts.Get(gaiaappparams.StateSyncKey))
-	bypassMinFeeMsgTypes, ok := appStateSync[gaiaappparams.BypassMinFeeMsgTypesKey]
-	if !ok || bypassMinFeeMsgTypes == nil {
+	bypassMinFeeMsgTypes := cast.ToStringSlice(appOpts.Get(gaiaappparams.BypassMinFeeMsgTypesKey))
+	if bypassMinFeeMsgTypes == nil {
 		bypassMinFeeMsgTypes = GetDefaultBypassFeeMessages()
 	}
 
@@ -704,7 +703,7 @@ func NewGaiaApp(
 				},
 			},
 			IBCkeeper:            app.IBCKeeper,
-			BypassMinFeeMsgTypes: cast.ToStringSlice(bypassMinFeeMsgTypes),
+			BypassMinFeeMsgTypes: bypassMinFeeMsgTypes,
 			GlobalFeeSubspace:    app.GetSubspace(globalfee.ModuleName),
 		},
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -676,11 +676,9 @@ func NewGaiaApp(
 	app.MountTransientStores(tkeys)
 	app.MountMemoryStores(memKeys)
 
-	var bypassMinFeeMsgTypes []string
-	bypassMinFeeConfig := appOpts.Get(gaiaappparams.BypassMinFeeMsgTypesKey)
-	if bypassMinFeeConfig != nil {
-		bypassMinFeeMsgTypes = cast.ToStringSlice(bypassMinFeeConfig)
-	} else {
+	appStateSync := cast.ToStringMap(appOpts.Get(gaiaappparams.StateSyncKey))
+	bypassMinFeeMsgTypes, ok := appStateSync[gaiaappparams.BypassMinFeeMsgTypesKey]
+	if !ok || bypassMinFeeMsgTypes == nil {
 		bypassMinFeeMsgTypes = GetDefaultBypassFeeMessages()
 	}
 
@@ -706,7 +704,7 @@ func NewGaiaApp(
 				},
 			},
 			IBCkeeper:            app.IBCKeeper,
-			BypassMinFeeMsgTypes: bypassMinFeeMsgTypes,
+			BypassMinFeeMsgTypes: cast.ToStringSlice(bypassMinFeeMsgTypes),
 			GlobalFeeSubspace:    app.GetSubspace(globalfee.ModuleName),
 		},
 	)

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -5,6 +5,11 @@ import (
 )
 
 var (
+	// StateSyncKey defines the configuration key for the
+	// app state-sync value.
+	//nolint: gosec
+	StateSyncKey = "state-sync"
+
 	// BypassMinFeeMsgTypesKey defines the configuration key for the
 	// BypassMinFeeMsgTypes value.
 	//nolint: gosec

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -1,6 +1,8 @@
 package params
 
 import (
+	"strings"
+
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 )
 
@@ -15,9 +17,8 @@ var (
 	//nolint: gosec
 	BypassMinFeeMsgTypesKey = "bypass-min-fee-msg-types"
 
-	// CustomConfigTemplate defines Gaia's custom application configuration TOML
-	// template. It extends the core SDK template.
-	CustomConfigTemplate = serverconfig.DefaultConfigTemplate + `
+	// customGaiaConfigTemplate defines Gaia's custom application configuration TOML template.
+	customGaiaConfigTemplate = `
 ###############################################################################
 ###                        Custom Gaia Configuration                        ###
 ###############################################################################
@@ -29,6 +30,16 @@ var (
 bypass-min-fee-msg-types = [{{ range .BypassMinFeeMsgTypes }}{{ printf "%q, " . }}{{end}}]
 `
 )
+
+// CustomConfigTemplate defines Gaia's custom application configuration TOML
+// template. It extends the core SDK template.
+func CustomConfigTemplate() string {
+	config := serverconfig.DefaultConfigTemplate
+	lines := strings.Split(config, "\n")
+	// add the Gaia config at the second line of the file
+	lines[2] += customGaiaConfigTemplate
+	return strings.Join(lines, "\n")
+}
 
 // CustomAppConfig defines Gaia's custom application configuration.
 type CustomAppConfig struct {

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -7,11 +7,6 @@ import (
 )
 
 var (
-	// StateSyncKey defines the configuration key for the
-	// app state-sync value.
-	//nolint: gosec
-	StateSyncKey = "state-sync"
-
 	// BypassMinFeeMsgTypesKey defines the configuration key for the
 	// BypassMinFeeMsgTypes value.
 	//nolint: gosec

--- a/cmd/gaiad/cmd/root.go
+++ b/cmd/gaiad/cmd/root.go
@@ -98,7 +98,7 @@ func initAppConfig() (string, interface{}) {
 	srvCfg.StateSync.SnapshotInterval = 1000
 	srvCfg.StateSync.SnapshotKeepRecent = 10
 
-	return params.CustomConfigTemplate, params.CustomAppConfig{
+	return params.CustomConfigTemplate(), params.CustomAppConfig{
 		Config:               *srvCfg,
 		BypassMinFeeMsgTypes: gaia.GetDefaultBypassFeeMessages(),
 	}


### PR DESCRIPTION
close #1486

## Description

The current `bypass-min-fee-msg-types` parameter is not parsing correctly from the `app.toml` config file. The chain is only using the default values.

## Solution

This PR fix the right variable path to use `state-sync.bypass-min-fee-msg-types` Instead from `bypass-min-fee-msg-types` only.