### PR TITLE
fix: Rectify e2e test deletion and e2e refactor

### DIFF
--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -398,7 +398,8 @@ func (s *IntegrationTestSuite) executeGKeysAddCommand(c *chain, valIdx int, name
 
 	var addrRecord AddressResponse
 	s.executeGaiaTxCommand(ctx, c, gaiaCommand, valIdx, func(stdOut []byte, stdErr []byte) bool {
-		if err := json.Unmarshal(stdOut, &addrRecord); err != nil {
+		// Gaiad keys add by default returns payload to stdErr
+		if err := json.Unmarshal(stdErr, &addrRecord); err != nil {
 			return false
 		}
 		return strings.Contains(addrRecord.Address, "cosmos")

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -670,3 +670,7 @@ func (s *IntegrationTestSuite) TestStaking() {
 	s.testStaking(chainAAPIEndpoint, alice.String(), valOperA.String(), valOperB.String(), delegationFees, gaiaHomePath)
 	s.testDistribution(chainAAPIEndpoint, alice.String(), bob.String(), valOperB.String(), gaiaHomePath)
 }
+
+func (s *IntegrationTestSuite) TestGroups() {
+	s.GroupsSendMsgTest()
+}


### PR DESCRIPTION
Reintroduces `group` e2e deleted in https://github.com/cosmos/gaia/pull/1683
Fixes validation error in`gaiad keys add` introduced in https://github.com/cosmos/gaia/pull/1749