### PR TITLE
Fix: use `bondDenom` as default globalfee denom

### DIFF
--- a/ante/ante.go
+++ b/ante/ante.go
@@ -18,6 +18,7 @@ type HandlerOptions struct {
 	IBCkeeper            *ibckeeper.Keeper
 	BypassMinFeeMsgTypes []string
 	GlobalFeeSubspace    paramtypes.Subspace
+	StakingSubspace      paramtypes.Subspace
 }
 
 func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
@@ -36,6 +37,9 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 	if opts.GlobalFeeSubspace.Name() == "" {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "param store is required for ante builder")
 	}
+	if opts.StakingSubspace.Name() == "" {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "param store is required for ante builder")
+	}
 
 	sigGasConsumer := opts.SigGasConsumer
 	if sigGasConsumer == nil {
@@ -49,7 +53,7 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(opts.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(opts.AccountKeeper),
-		gaiafeeante.NewFeeDecorator(opts.BypassMinFeeMsgTypes, opts.GlobalFeeSubspace),
+		gaiafeeante.NewFeeDecorator(opts.BypassMinFeeMsgTypes, opts.GlobalFeeSubspace, opts.StakingSubspace),
 		// if opts.TxFeeCheck is nil,  it is the default fee check
 		ante.NewDeductFeeDecorator(opts.AccountKeeper, opts.BankKeeper, opts.FeegrantKeeper, opts.TxFeeChecker),
 		ante.NewSetPubKeyDecorator(opts.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators

--- a/ante/ante.go
+++ b/ante/ante.go
@@ -35,10 +35,10 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "IBC keeper is required for AnteHandler")
 	}
 	if opts.GlobalFeeSubspace.Name() == "" {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "globalfee param store is required for AnteHandler")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrNotFound, "globalfee param store is required for AnteHandler")
 	}
 	if opts.StakingSubspace.Name() == "" {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "staking param store is required for AnteHandler")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrNotFound, "staking param store is required for AnteHandler")
 	}
 
 	sigGasConsumer := opts.SigGasConsumer

--- a/ante/ante.go
+++ b/ante/ante.go
@@ -29,16 +29,16 @@ func NewAnteHandler(opts HandlerOptions) (sdk.AnteHandler, error) {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for AnteHandler")
 	}
 	if opts.SignModeHandler == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for AnteHandler")
 	}
 	if opts.IBCkeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "IBC keeper is required for middlewares")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "IBC keeper is required for AnteHandler")
 	}
 	if opts.GlobalFeeSubspace.Name() == "" {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "param store is required for ante builder")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "globalfee param store is required for AnteHandler")
 	}
 	if opts.StakingSubspace.Name() == "" {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "param store is required for ante builder")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "staking param store is required for AnteHandler")
 	}
 
 	sigGasConsumer := opts.SigGasConsumer

--- a/app/app.go
+++ b/app/app.go
@@ -26,6 +26,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
@@ -212,6 +213,7 @@ func NewGaiaApp(
 			IBCkeeper:            app.IBCKeeper,
 			BypassMinFeeMsgTypes: bypassMinFeeMsgTypes,
 			GlobalFeeSubspace:    app.GetSubspace(globalfee.ModuleName),
+			StakingSubspace:      app.GetSubspace(stakingtypes.ModuleName),
 		},
 	)
 	if err != nil {

--- a/x/globalfee/ante/antetest/fee_test.go
+++ b/x/globalfee/ante/antetest/fee_test.go
@@ -536,9 +536,10 @@ func (s *IntegrationTestSuite) TestGlobalFeeMinimumGasFeeAnteHandler() {
 	for name, testCase := range testCases {
 		s.Run(name, func() {
 			// set globalfees and min gas price
-			subspace := s.SetupTestGlobalFeeStoreAndMinGasPrice(testCase.minGasPrice, testCase.globalFeeParams)
+			globalfeeSubspace := s.SetupTestGlobalFeeStoreAndMinGasPrice(testCase.minGasPrice, testCase.globalFeeParams)
+			stakingSubspace := s.SetupTestStakingSubspace()
 			// setup antehandler
-			mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), subspace)
+			mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), globalfeeSubspace, stakingSubspace)
 			antehandler := sdk.ChainAnteDecorators(mfd)
 
 			s.Require().NoError(s.txBuilder.SetMsgs(testCase.txMsg))

--- a/x/globalfee/ante/antetest/fee_test.go
+++ b/x/globalfee/ante/antetest/fee_test.go
@@ -19,6 +19,18 @@ func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
 }
 
+func (s *IntegrationTestSuite) TestGetDefaultGlobalFees() {
+	bondDenom := "uatom"
+	// set globalfees and min gas price
+	globalfeeSubspace := s.SetupTestGlobalFeeStoreAndMinGasPrice([]sdk.DecCoin{}, &globfeetypes.Params{})
+	stakingSubspace := s.SetupTestStakingSubspace(bondDenom)
+	// setup antehandler
+	mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), globalfeeSubspace, stakingSubspace)
+	if mfd.DefaultZeroGlobalFee(s.ctx)[0].Denom != bondDenom {
+		s.T().Fatalf("bond denom: %s, default global fee denom: %s", bondDenom, mfd.DefaultZeroGlobalFee(s.ctx)[0].Denom)
+	}
+}
+
 // test global fees and min_gas_price with bypass msg types.
 // please note even globalfee=0, min_gas_price=0, we do not let fee=0random_denom pass
 // paid fees are already sanitized by removing zero coins(through feeFlag parsing), so use sdk.NewCoins() to create it.
@@ -537,7 +549,7 @@ func (s *IntegrationTestSuite) TestGlobalFeeMinimumGasFeeAnteHandler() {
 		s.Run(name, func() {
 			// set globalfees and min gas price
 			globalfeeSubspace := s.SetupTestGlobalFeeStoreAndMinGasPrice(testCase.minGasPrice, testCase.globalFeeParams)
-			stakingSubspace := s.SetupTestStakingSubspace()
+			stakingSubspace := s.SetupTestStakingSubspace("uatom")
 			// setup antehandler
 			mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), globalfeeSubspace, stakingSubspace)
 			antehandler := sdk.ChainAnteDecorators(mfd)

--- a/x/globalfee/ante/antetest/fee_test.go
+++ b/x/globalfee/ante/antetest/fee_test.go
@@ -35,6 +35,7 @@ func (s *IntegrationTestSuite) TestGetDefaultGlobalFees() {
 
 	defaultGlobalFees, err := mfd.DefaultZeroGlobalFee(s.ctx)
 	s.Require().NoError(err)
+	s.Require().Greater(len(defaultGlobalFees), 0)
 
 	if defaultGlobalFees[0].Denom != bondDenom {
 		s.T().Fatalf("bond denom: %s, default global fee denom: %s", bondDenom, defaultGlobalFees[0].Denom)

--- a/x/globalfee/ante/antetest/fee_test.go
+++ b/x/globalfee/ante/antetest/fee_test.go
@@ -26,8 +26,12 @@ func (s *IntegrationTestSuite) TestGetDefaultGlobalFees() {
 	stakingSubspace := s.SetupTestStakingSubspace(bondDenom)
 	// setup antehandler
 	mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), globalfeeSubspace, stakingSubspace)
-	if mfd.DefaultZeroGlobalFee(s.ctx)[0].Denom != bondDenom {
-		s.T().Fatalf("bond denom: %s, default global fee denom: %s", bondDenom, mfd.DefaultZeroGlobalFee(s.ctx)[0].Denom)
+
+	defaultGlobalFees, err := mfd.DefaultZeroGlobalFee(s.ctx)
+	s.Require().NoError(err)
+
+	if defaultGlobalFees[0].Denom != bondDenom {
+		s.T().Fatalf("bond denom: %s, default global fee denom: %s", bondDenom, defaultGlobalFees[0].Denom)
 	}
 }
 

--- a/x/globalfee/ante/antetest/fee_test.go
+++ b/x/globalfee/ante/antetest/fee_test.go
@@ -6,6 +6,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	"github.com/stretchr/testify/suite"
@@ -20,10 +21,15 @@ func TestIntegrationTestSuite(t *testing.T) {
 }
 
 func (s *IntegrationTestSuite) TestGetDefaultGlobalFees() {
-	bondDenom := "uatom"
 	// set globalfees and min gas price
 	globalfeeSubspace := s.SetupTestGlobalFeeStoreAndMinGasPrice([]sdk.DecCoin{}, &globfeetypes.Params{})
-	stakingSubspace := s.SetupTestStakingSubspace(bondDenom)
+
+	// set staking params
+	stakingParam := stakingtypes.DefaultParams()
+	bondDenom := "uatom"
+	stakingParam.BondDenom = bondDenom
+	stakingSubspace := s.SetupTestStakingSubspace(stakingParam)
+
 	// setup antehandler
 	mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), globalfeeSubspace, stakingSubspace)
 
@@ -553,7 +559,9 @@ func (s *IntegrationTestSuite) TestGlobalFeeMinimumGasFeeAnteHandler() {
 		s.Run(name, func() {
 			// set globalfees and min gas price
 			globalfeeSubspace := s.SetupTestGlobalFeeStoreAndMinGasPrice(testCase.minGasPrice, testCase.globalFeeParams)
-			stakingSubspace := s.SetupTestStakingSubspace("uatom")
+			stakingParam := stakingtypes.DefaultParams()
+			stakingParam.BondDenom = "uatom"
+			stakingSubspace := s.SetupTestStakingSubspace(stakingParam)
 			// setup antehandler
 			mfd := gaiafeeante.NewFeeDecorator(gaiaapp.GetDefaultBypassFeeMessages(), globalfeeSubspace, stakingSubspace)
 			antehandler := sdk.ChainAnteDecorators(mfd)

--- a/x/globalfee/ante/antetest/fee_test_setup.go
+++ b/x/globalfee/ante/antetest/fee_test_setup.go
@@ -56,8 +56,8 @@ func (s *IntegrationTestSuite) SetupTestGlobalFeeStoreAndMinGasPrice(minGasPrice
 }
 
 // SetupTestStakingSubspace sets uatom as bond denom for the fee tests.
-func (s *IntegrationTestSuite) SetupTestStakingSubspace() types.Subspace {
-	s.app.GetSubspace(stakingtypes.ModuleName).Set(s.ctx, stakingtypes.KeyBondDenom, "uatom")
+func (s *IntegrationTestSuite) SetupTestStakingSubspace(bondDenom string) types.Subspace {
+	s.app.GetSubspace(stakingtypes.ModuleName).Set(s.ctx, stakingtypes.KeyBondDenom, bondDenom)
 	return s.app.GetSubspace(stakingtypes.ModuleName)
 }
 

--- a/x/globalfee/ante/antetest/fee_test_setup.go
+++ b/x/globalfee/ante/antetest/fee_test_setup.go
@@ -56,8 +56,8 @@ func (s *IntegrationTestSuite) SetupTestGlobalFeeStoreAndMinGasPrice(minGasPrice
 }
 
 // SetupTestStakingSubspace sets uatom as bond denom for the fee tests.
-func (s *IntegrationTestSuite) SetupTestStakingSubspace(bondDenom string) types.Subspace {
-	s.app.GetSubspace(stakingtypes.ModuleName).Set(s.ctx, stakingtypes.KeyBondDenom, bondDenom)
+func (s *IntegrationTestSuite) SetupTestStakingSubspace(params stakingtypes.Params) types.Subspace {
+	s.app.GetSubspace(stakingtypes.ModuleName).SetParamSet(s.ctx, &params)
 	return s.app.GetSubspace(stakingtypes.ModuleName)
 }
 

--- a/x/globalfee/ante/antetest/fee_test_setup.go
+++ b/x/globalfee/ante/antetest/fee_test_setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/cosmos/cosmos-sdk/x/params/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gaiahelpers "github.com/cosmos/gaia/v8/app/helpers"
 	"github.com/stretchr/testify/suite"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -52,6 +53,12 @@ func (s *IntegrationTestSuite) SetupTestGlobalFeeStoreAndMinGasPrice(minGasPrice
 	s.ctx = s.ctx.WithMinGasPrices(minGasPrice).WithIsCheckTx(true)
 
 	return subspace
+}
+
+// in the fee test, set uatom as bond denom.
+func (s *IntegrationTestSuite) SetupTestStakingSubspace() types.Subspace {
+	s.app.GetSubspace(stakingtypes.ModuleName).Set(s.ctx, stakingtypes.KeyBondDenom, "uatom")
+	return s.app.GetSubspace(stakingtypes.ModuleName)
 }
 
 func (s *IntegrationTestSuite) CreateTestTx(privs []cryptotypes.PrivKey, accNums []uint64, accSeqs []uint64, chainID string) (xauthsigning.Tx, error) {

--- a/x/globalfee/ante/antetest/fee_test_setup.go
+++ b/x/globalfee/ante/antetest/fee_test_setup.go
@@ -55,7 +55,7 @@ func (s *IntegrationTestSuite) SetupTestGlobalFeeStoreAndMinGasPrice(minGasPrice
 	return subspace
 }
 
-// in the fee test, set uatom as bond denom.
+// SetupTestStakingSubspace sets uatom as bond denom for the fee tests.
 func (s *IntegrationTestSuite) SetupTestStakingSubspace() types.Subspace {
 	s.app.GetSubspace(stakingtypes.ModuleName).Set(s.ctx, stakingtypes.KeyBondDenom, "uatom")
 	return s.app.GetSubspace(stakingtypes.ModuleName)

--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -26,22 +26,22 @@ var _ sdk.AnteDecorator = FeeDecorator{}
 type FeeDecorator struct {
 	BypassMinFeeMsgTypes []string
 	GlobalMinFee         globalfee.ParamSource
+	StakingSubspace      paramtypes.Subspace
 }
 
-const defaultZeroGlobalFeeDenom = "uatom"
-
-func DefaultZeroGlobalFee() []sdk.DecCoin {
-	return []sdk.DecCoin{sdk.NewDecCoinFromDec(defaultZeroGlobalFeeDenom, sdk.NewDec(0))}
-}
-
-func NewFeeDecorator(bypassMsgTypes []string, paramSpace paramtypes.Subspace) FeeDecorator {
-	if !paramSpace.HasKeyTable() {
+func NewFeeDecorator(bypassMsgTypes []string, globalfeeSubspace, stakingSubspace paramtypes.Subspace) FeeDecorator {
+	if !globalfeeSubspace.HasKeyTable() {
 		panic("global fee paramspace was not set up via module")
+	}
+
+	if !stakingSubspace.HasKeyTable() {
+		panic("staking paramspace was not set up via module")
 	}
 
 	return FeeDecorator{
 		BypassMinFeeMsgTypes: bypassMsgTypes,
-		GlobalMinFee:         paramSpace,
+		GlobalMinFee:         globalfeeSubspace,
+		StakingSubspace:      stakingSubspace,
 	}
 }
 

--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -104,8 +104,11 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 
 // ParamStoreKeyMinGasPrices type require coins sorted. getGlobalFee will also return sorted coins (might return 0denom if globalMinGasPrice is 0)
 func (mfd FeeDecorator) getGlobalFee(ctx sdk.Context, feeTx sdk.FeeTx) sdk.Coins {
-	var globalMinGasPrices sdk.DecCoins
-	var err error
+	var (
+		globalMinGasPrices sdk.DecCoins
+		err                error
+	)
+
 	if mfd.GlobalMinFee.Has(ctx, types.ParamStoreKeyMinGasPrices) {
 		mfd.GlobalMinFee.Get(ctx, types.ParamStoreKeyMinGasPrices, &globalMinGasPrices)
 	}
@@ -131,7 +134,7 @@ func (mfd FeeDecorator) getGlobalFee(ctx sdk.Context, feeTx sdk.FeeTx) sdk.Coins
 func (mfd FeeDecorator) DefaultZeroGlobalFee(ctx sdk.Context) ([]sdk.DecCoin, error) {
 	bondDenom := mfd.getBondDenom(ctx)
 	if bondDenom == "" {
-		return []sdk.DecCoin{}, errors.New("empty staking bond denomination")
+		return nil, errors.New("empty staking bond denomination")
 	}
 
 	return []sdk.DecCoin{sdk.NewDecCoinFromDec(bondDenom, sdk.NewDec(0))}, nil

--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -1,9 +1,13 @@
 package ante
 
 import (
+	"errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/gaia/v8/x/globalfee/types"
 
 	"github.com/cosmos/gaia/v8/x/globalfee"
 )
@@ -96,4 +100,48 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 	}
 
 	return next(ctx, tx, simulate)
+}
+
+// ParamStoreKeyMinGasPrices type require coins sorted. getGlobalFee will also return sorted coins (might return 0denom if globalMinGasPrice is 0)
+func (mfd FeeDecorator) getGlobalFee(ctx sdk.Context, feeTx sdk.FeeTx) sdk.Coins {
+	var globalMinGasPrices sdk.DecCoins
+	var err error
+	if mfd.GlobalMinFee.Has(ctx, types.ParamStoreKeyMinGasPrices) {
+		mfd.GlobalMinFee.Get(ctx, types.ParamStoreKeyMinGasPrices, &globalMinGasPrices)
+	}
+	// global fee is empty set, set global fee to 0uatom
+	if len(globalMinGasPrices) == 0 {
+		globalMinGasPrices, err = mfd.DefaultZeroGlobalFee(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}
+	requiredGlobalFees := make(sdk.Coins, len(globalMinGasPrices))
+	// Determine the required fees by multiplying each required minimum gas
+	// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+	glDec := sdk.NewDec(int64(feeTx.GetGas()))
+	for i, gp := range globalMinGasPrices {
+		fee := gp.Amount.Mul(glDec)
+		requiredGlobalFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
+	}
+
+	return requiredGlobalFees.Sort()
+}
+
+func (mfd FeeDecorator) DefaultZeroGlobalFee(ctx sdk.Context) ([]sdk.DecCoin, error) {
+	bondDenom := mfd.getBondDenom(ctx)
+	if bondDenom == "" {
+		return []sdk.DecCoin{}, errors.New("empty staking bond denomination")
+	}
+
+	return []sdk.DecCoin{sdk.NewDecCoinFromDec(bondDenom, sdk.NewDec(0))}, nil
+}
+
+func (mfd FeeDecorator) getBondDenom(ctx sdk.Context) string {
+	var bondDenom string
+	if mfd.StakingSubspace.Has(ctx, stakingtypes.KeyBondDenom) {
+		mfd.StakingSubspace.Get(ctx, stakingtypes.KeyBondDenom, &bondDenom)
+	}
+
+	return bondDenom
 }

--- a/x/globalfee/ante/fee_utils.go
+++ b/x/globalfee/ante/fee_utils.go
@@ -34,7 +34,6 @@ func (mfd FeeDecorator) getGlobalFee(ctx sdk.Context, feeTx sdk.FeeTx) sdk.Coins
 
 func (mfd FeeDecorator) DefaultZeroGlobalFee(ctx sdk.Context) []sdk.DecCoin {
 	bondDenom := mfd.getBondDenom(ctx)
-	// todo: check bonddenom is only one denom
 	if bondDenom == "" {
 		panic("staking bond denom is empty")
 	}

--- a/x/globalfee/ante/fee_utils.go
+++ b/x/globalfee/ante/fee_utils.go
@@ -34,7 +34,8 @@ func (mfd FeeDecorator) getGlobalFee(ctx sdk.Context, feeTx sdk.FeeTx) sdk.Coins
 
 func (mfd FeeDecorator) DefaultZeroGlobalFee(ctx sdk.Context) []sdk.DecCoin {
 	bondDenom := mfd.getBondDenom(ctx)
-	if bondDenom == "" { //todo: check bonddenom is only one denom
+	// todo: check bonddenom is only one denom
+	if bondDenom == "" {
 		panic("staking bond denom is empty")
 	}
 


### PR DESCRIPTION
## Fix: use `bondDenom` in staking module of the denom of defalut global fee.
closes: #1823

To fix issue #1823, stakingParams will be added to `FeeDecorator` for antehandler to access bondDnom. Default globalfee is configured the same as the chain's bonddenom, rather than hardcoded `uatom`