### PR TITLE
Updated and new links

### DIFF
--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -20,6 +20,8 @@ If you'd like to draft a proposal, start [here](./best-practices.md).
 See the contents below for more background on the governance system,
 the different types of proposals, and how to submit one.
 
+ATOM stakers can find active on-chain proposals to vote on [here](https://www.mintscan.io/cosmos/proposals).
+
 ## Contents
 
 - [On-Chain Process](./process.md)
@@ -41,5 +43,6 @@ community members, including:
 
 - [Forum](http://forum.cosmos.network/)
 - [Reddit](http://reddit.com/r/cosmosnetwork)
-- [Telegram (Governance Working Group)](https://t.me/hubgov)
+- [Telegram](https://t.me/cosmosproject)
 - anywhere else you might interact with members of the Cosmos community!
+

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -43,6 +43,6 @@ community members, including:
 
 - [Forum](http://forum.cosmos.network/)
 - [Reddit](http://reddit.com/r/cosmosnetwork)
-- [Telegram](https://t.me/cosmosproject)
+- [Telegram](https://t.me/atomgov)
 - anywhere else you might interact with members of the Cosmos community!
 


### PR DESCRIPTION
Current Telegram link directs to a chat that no longer exists, replaced it with the main Cosmos Telegram group. Also added link to Mintscan's page of on-chain proposals