### PR TITLE
refactor: simplify the logic in fee antehandler

### DIFF
--- a/x/globalfee/ante/antetest/fee_test.go
+++ b/x/globalfee/ante/antetest/fee_test.go
@@ -555,6 +555,15 @@ func (s *IntegrationTestSuite) TestGlobalFeeMinimumGasFeeAnteHandler() {
 			txCheck:         false,
 			expErr:          false,
 		},
+		"disable checkTx: no fee check. min_gas_price is low, global fee is low, tx fee's denom is not in global fees denoms set": {
+			minGasPrice:     minGasPrice,
+			globalFeeParams: globalfeeParamsLow,
+			gasPrice:        sdk.NewCoins(sdk.NewCoin("quark", sdk.ZeroInt())),
+			gasLimit:        newTestGasLimit(),
+			txMsg:           testdata.NewTestMsg(addr1),
+			txCheck:         false,
+			expErr:          false,
+		},
 	}
 	for name, testCase := range testCases {
 		s.Run(name, func() {

--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -74,7 +74,7 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 	}
 	requiredFees := getMinGasPrice(ctx, feeTx)
 
-	if !ctx.IsCheckTx() && simulate {
+	if !ctx.IsCheckTx() || simulate {
 		return next(ctx, tx, simulate)
 	}
 


### PR DESCRIPTION
closes:  #1872
# refactor fee antehandler:
- return early when `!ctx.IsCheckTx() && simulate`
```	
if !ctx.IsCheckTx() && simulate {
		return next(ctx, tx, simulate)
	}
```
- move `getGlobalFee` out if condition.
- add one more test case for disable checkTx: tx fee's denom is not in global fees denoms set

