### PR TITLE
fix: print in app.go

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -85,7 +85,7 @@ type GaiaApp struct { //nolint: revive
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		stdlog.Println("Failed to get home dir %2", err)
+		stdlog.Printf("Failed to get home dir %s", err.Error())
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, ".gaia")

--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,6 @@ package gaia
 import (
 	"fmt"
 	"io"
-	stdlog "log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -85,7 +84,7 @@ type GaiaApp struct { //nolint: revive
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		stdlog.Printf("Failed to get home dir %s", err.Error())
+		panic(err)
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, ".gaia")


### PR DESCRIPTION
close #1873
close #1874

panic rather than print the err in gaiad init when `os.UserHomeDir()` return err.