### PR TITLE
bump ICS version to 0.2.1 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.7-0.20221104161803-456ca5663c5e
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v3 v3.0.0
-	github.com/cosmos/interchain-security v0.2.0
+	github.com/cosmos/interchain-security v0.2.1
 	github.com/golangci/golangci-lint v1.45.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gravity-devs/liquidity v1.4.5

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/cosmos/interchain-security v0.0.0-20221028153426-602b7ed47785 h1:t2Bz
 github.com/cosmos/interchain-security v0.0.0-20221028153426-602b7ed47785/go.mod h1:MmQ0Wh7TvzZkAnHMQR/sd7fy+cx35lp/7ZvVXNDqf/o=
 github.com/cosmos/interchain-security v0.2.0 h1:YAfy1QqDrAVTOu6HOXuimOJ34RkD2SzQuwk6o1DYrfs=
 github.com/cosmos/interchain-security v0.2.0/go.mod h1:Ntu6JyaSD0pH+HJYCgHsyYX6FJxk0gCDR8D4SYbbxA4=
+github.com/cosmos/interchain-security v0.2.1 h1:wzg1ydRtm4h+Xce87kQvD8OWNCNEkSVjCCb5khyS6b8=
+github.com/cosmos/interchain-security v0.2.1/go.mod h1:Ntu6JyaSD0pH+HJYCgHsyYX6FJxk0gCDR8D4SYbbxA4=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=


### PR DESCRIPTION
Bumping ICS version to https://github.com/cosmos/interchain-security/releases/tag/v0.2.1 for incentivized testnet