### PR TITLE
docs: correct `NoWithVeto` condition description

### DIFF
--- a/docs/governance/process.md
+++ b/docs/governance/process.md
@@ -29,7 +29,7 @@ The voting period is currently a fixed 14-day period. During the voting period, 
 1. **Abstain:** indicates that the voter is impartial to the outcome of the proposal.
 2. **Yes:** indicates approval of the proposal in its current form.
 3. **No:** indicates disapproval of the proposal in its current form.
-4. **NoWithVeto:** indicates stronger opposition to the proposal than simply voting 'No'. If the number of 'NoWithVeto' votes is greater than a third of total votes excluding 'Abstain' votes, the proposal is rejected and the deposits are [burned](#burned-deposits).
+4. **NoWithVeto:** indicates stronger opposition to the proposal than simply voting 'No'. If the number of 'NoWithVeto' votes is greater than a third of total votes including 'Abstain' votes, the proposal is rejected and the deposits are [burned](#burned-deposits).
 
 As accepted by the community in [Proposal 6](https://ipfs.io/ipfs/QmRtR7qkeaZCpCzHDwHgJeJAZdTrbmHLxFDYXhw7RoF1pp), voters are expected to vote 'NoWithVeto' if a proposal leads to undesireable outcomes for the community. It states “if a proposal seems to be spam or is deemed to have caused a negative externality to Cosmos community, voters should vote _NoWithVeto_.”
 


### PR DESCRIPTION
According to [docs](https://docs.cosmos.network/main/modules/gov#threshold) and [code](https://github.com/cosmos/cosmos-sdk/blob/bcff22a3767b9c5dd7d1d562aece90cf72e05e85/x/gov/keeper/tally.go#L115), it includes `abstain` when calculating the threshold of `NoWithVeto`.