### PR TITLE
fix: feegrant e2e test

### DIFF
--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -30,7 +30,7 @@ const (
 	flagChainID         = "chain-id"
 	flagSpendLimit      = "spend-limit"
 	flagGasAdjustment   = "gas-adjustment"
-	flagFeeGranter      = "fee-granter"
+	flagFeeAccount      = "fee-account"
 	flagBroadcastMode   = "broadcast-mode"
 	flagKeyringBackend  = "keyring-backend"
 	flagAllowedMessages = "allowed-messages"

--- a/tests/e2e/e2e_feegrant_test.go
+++ b/tests/e2e/e2e_feegrant_test.go
@@ -20,17 +20,17 @@ func (s *IntegrationTestSuite) testFeeGrant() {
 	s.Run("test fee grant module", func() {
 		var (
 			valIdx = 0
-			chain  = s.chainA
-			api    = fmt.Sprintf("http://%s", s.valResources[chain.id][valIdx].GetHostPort("1317/tcp"))
+			c      = s.chainA
+			api    = fmt.Sprintf("http://%s", s.valResources[c.id][valIdx].GetHostPort("1317/tcp"))
 		)
 
-		alice := chain.genesisAccounts[1].keyInfo.GetAddress()
-		bob := chain.genesisAccounts[2].keyInfo.GetAddress()
-		charlie := chain.genesisAccounts[3].keyInfo.GetAddress()
+		alice := c.genesisAccounts[1].keyInfo.GetAddress()
+		bob := c.genesisAccounts[2].keyInfo.GetAddress()
+		charlie := c.genesisAccounts[3].keyInfo.GetAddress()
 
 		// add fee grant from alice to bob
 		s.execFeeGrant(
-			chain,
+			c,
 			valIdx,
 			alice.String(),
 			bob.String(),
@@ -43,14 +43,14 @@ func (s *IntegrationTestSuite) testFeeGrant() {
 
 		// withdrawal all balance + fee + fee granter flag should succeed
 		s.execBankSend(
-			chain,
+			c,
 			valIdx,
 			bob.String(),
 			Address(),
 			tokenAmount.String(),
 			standardFees.String(),
 			false,
-			withKeyValue(flagFeeGranter, alice.String()),
+			withKeyValue(flagFeeAccount, alice.String()),
 		)
 
 		// check if the bob balance was subtracted without the fees
@@ -61,19 +61,19 @@ func (s *IntegrationTestSuite) testFeeGrant() {
 
 		// tx should fail after spend limit reach
 		s.execBankSend(
-			chain,
+			c,
 			valIdx,
 			bob.String(),
 			Address(),
 			tokenAmount.String(),
 			standardFees.String(),
 			true,
-			withKeyValue(flagFeeGranter, alice.String()),
+			withKeyValue(flagFeeAccount, alice.String()),
 		)
 
 		// add fee grant from alice to charlie
 		s.execFeeGrant(
-			chain,
+			c,
 			valIdx,
 			alice.String(),
 			charlie.String(),
@@ -83,7 +83,7 @@ func (s *IntegrationTestSuite) testFeeGrant() {
 
 		// revoke fee grant from alice to charlie
 		s.execFeeGrantRevoke(
-			chain,
+			c,
 			valIdx,
 			alice.String(),
 			charlie.String(),
@@ -91,14 +91,14 @@ func (s *IntegrationTestSuite) testFeeGrant() {
 
 		// tx should fail because the grant was revoked
 		s.execBankSend(
-			chain,
+			c,
 			valIdx,
 			charlie.String(),
 			Address(),
 			tokenAmount.String(),
 			standardFees.String(),
 			true,
-			withKeyValue(flagFeeGranter, alice.String()),
+			withKeyValue(flagFeeAccount, alice.String()),
 		)
 	})
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -9,7 +9,7 @@ var (
 	runBypassMinFeeTest           = true
 	runEncodeTest                 = true
 	runEvidenceTest               = true
-	runFeeGrantTest               = false // not sure why this isn't working
+	runFeeGrantTest               = true
 	runGlobalFeesTest             = true
 	runGovTest                    = false // legacy gov system needs to be added back
 	runIBCTest                    = false // multihop ibc test is not working


### PR DESCRIPTION
- fix feegrant e2e test for downgrading to sdk v0.45   
- rename `chain` -> `c` due to name collision