### PR TITLE
fix: correct ica wiring and update pfm fixes for v8 upgrade

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -272,12 +272,11 @@ func NewAppKeeper(
 		govRouter,
 	)
 
-	// TODO: Confirm TransferKeeper wiring correct after strangelove backports https://github.com/strangelove-ventures/packet-forward-middleware/blob/6867bcaac00fef1267c4ea99c3cbb6ee8bc6a025/router/keeper/keeper.go#L49
 	appKeepers.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
 		appKeepers.keys[ibctransfertypes.StoreKey],
 		appKeepers.GetSubspace(ibctransfertypes.ModuleName),
-		appKeepers.RouterKeeper,
+		appKeepers.IBCKeeper.ChannelKeeper,
 		appKeepers.IBCKeeper.ChannelKeeper,
 		&appKeepers.IBCKeeper.PortKeeper,
 		appKeepers.AccountKeeper,

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -272,11 +272,12 @@ func NewAppKeeper(
 		govRouter,
 	)
 
+	// TODO: Confirm TransferKeeper wiring correct after strangelove backports https://github.com/strangelove-ventures/packet-forward-middleware/blob/6867bcaac00fef1267c4ea99c3cbb6ee8bc6a025/router/keeper/keeper.go#L49
 	appKeepers.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
 		appKeepers.keys[ibctransfertypes.StoreKey],
 		appKeepers.GetSubspace(ibctransfertypes.ModuleName),
-		appKeepers.IBCKeeper.ChannelKeeper,
+		appKeepers.RouterKeeper,
 		appKeepers.IBCKeeper.ChannelKeeper,
 		&appKeepers.IBCKeeper.PortKeeper,
 		appKeepers.AccountKeeper,

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -91,7 +91,7 @@ type AppKeepers struct {
 	AuthzKeeper     authzkeeper.Keeper
 	LiquidityKeeper liquiditykeeper.Keeper
 
-	RouterKeeper routerkeeper.Keeper
+	RouterKeeper *routerkeeper.Keeper
 
 	// Modules
 	ICAModule      ica.AppModule
@@ -276,7 +276,7 @@ func NewAppKeeper(
 		appCodec,
 		appKeepers.keys[ibctransfertypes.StoreKey],
 		appKeepers.GetSubspace(ibctransfertypes.ModuleName),
-		appKeepers.IBCKeeper.ChannelKeeper,
+		*appKeepers.RouterKeeper,
 		appKeepers.IBCKeeper.ChannelKeeper,
 		&appKeepers.IBCKeeper.PortKeeper,
 		appKeepers.AccountKeeper,
@@ -298,7 +298,7 @@ func NewAppKeeper(
 	appKeepers.ICAModule = ica.NewAppModule(nil, &appKeepers.ICAHostKeeper)
 	icaHostIBCModule := icahost.NewIBCModule(appKeepers.ICAHostKeeper)
 
-	appKeepers.RouterKeeper = routerkeeper.NewKeeper(
+	*appKeepers.RouterKeeper = routerkeeper.NewKeeper(
 		appCodec, appKeepers.keys[routertypes.StoreKey],
 		appKeepers.GetSubspace(routertypes.ModuleName),
 		appKeepers.TransferKeeper,
@@ -309,13 +309,13 @@ func NewAppKeeper(
 		appKeepers.IBCKeeper.ChannelKeeper,
 	)
 
-	appKeepers.RouterModule = router.NewAppModule(appKeepers.RouterKeeper)
+	appKeepers.RouterModule = router.NewAppModule(*appKeepers.RouterKeeper)
 
 	var ibcStack porttypes.IBCModule
 	ibcStack = transfer.NewIBCModule(appKeepers.TransferKeeper)
 	ibcStack = router.NewIBCMiddleware(
 		ibcStack,
-		appKeepers.RouterKeeper,
+		*appKeepers.RouterKeeper,
 		0,
 		routerkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
 		routerkeeper.DefaultRefundTransferPacketTimeoutTimestamp,

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -296,6 +296,7 @@ func NewAppKeeper(
 		bApp.MsgServiceRouter(),
 	)
 
+	appKeepers.ICAModule = ica.NewAppModule(nil, &appKeepers.ICAHostKeeper)
 	icaHostIBCModule := icahost.NewIBCModule(appKeepers.ICAHostKeeper)
 
 	appKeepers.RouterKeeper = routerkeeper.NewKeeper(

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -16,7 +16,6 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	icacontrollertypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types"
 	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	ibchost "github.com/cosmos/ibc-go/v3/modules/core/24-host"
@@ -33,7 +32,7 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
 		evidencetypes.StoreKey, liquiditytypes.StoreKey, ibctransfertypes.StoreKey,
 		capabilitytypes.StoreKey, feegrant.StoreKey, authzkeeper.StoreKey, routertypes.StoreKey,
-		icacontrollertypes.StoreKey, icahosttypes.StoreKey,
+		icahosttypes.StoreKey,
 	)
 
 	// Define transient store keys

--- a/app/modules.go
+++ b/app/modules.go
@@ -193,7 +193,6 @@ func orderBeginBlockers() []string {
 		feegrant.ModuleName,
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
-		icatypes.ModuleName,
 		globalfee.ModuleName,
 	}
 }
@@ -221,7 +220,6 @@ func orderEndBlockers() []string {
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 		vestingtypes.ModuleName,
-		icatypes.ModuleName,
 		globalfee.ModuleName,
 	}
 }
@@ -246,7 +244,6 @@ func orderInitBlockers() []string {
 		authz.ModuleName,
 		feegrant.ModuleName,
 		routertypes.ModuleName,
-		icatypes.ModuleName,
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 		vestingtypes.ModuleName,

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -36,14 +36,14 @@ func FixBankMetadata(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 		// confirm whether the old key is still accessible
 		_, foundMalformed = keepers.BankKeeper.GetDenomMetaData(ctx, malformedDenom)
 		if foundMalformed {
-			return errors.New("Malformed 'uatomu' denom not fixed")
+			return errors.New("malformed 'uatomu' denom not fixed")
 		}
 	}
 
 	// proceed with the original intention of populating the missing Name and Symbol fields
 	atomMetaData, foundCorrect := keepers.BankKeeper.GetDenomMetaData(ctx, correctDenom)
 	if !foundCorrect {
-		return errors.New("Atom denom not found")
+		return errors.New("atom denom not found")
 	}
 
 	atomMetaData.Name = "Cosmos Hub Atom"
@@ -61,11 +61,11 @@ func QuicksilverFix(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 	// Refund stuck coins from ica address
 	sourceAddress, err := sdk.AccAddressFromBech32("cosmos13dqvh4qtg4gzczuktgnw8gc2ewnwmhdwnctekxctyr4azz4dcyysecgq7e")
 	if err != nil {
-		return errors.New("Invalid source address")
+		return errors.New("invalid source address")
 	}
 	destinationAddress, err := sdk.AccAddressFromBech32("cosmos1jc24kwznud9m3mwqmcz3xw33ndjuufnghstaag")
 	if err != nil {
-		return errors.New("Invalid destination address")
+		return errors.New("invalid destination address")
 	}
 
 	// Get balance from stuck address and subtract 1 uatom sent by bad actor
@@ -74,7 +74,7 @@ func QuicksilverFix(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 		refundBalance := sourceBalance.SubAmount(sdk.NewInt(1))
 		err = keepers.BankKeeper.SendCoins(ctx, sourceAddress, destinationAddress, sdk.NewCoins(refundBalance))
 		if err != nil {
-			return errors.New("Unable to refund coins")
+			return errors.New("unable to refund coins")
 		}
 	}
 
@@ -108,7 +108,7 @@ func CreateUpgradeHandler(
 
 		err := FixBankMetadata(ctx, keepers)
 		if err != nil {
-			ctx.Logger().Info(fmt.Sprintf("Error fixing bank metadata: %s", err.Error()))
+			ctx.Logger().Info(fmt.Sprintf("error fixing bank metadata: %s", err.Error()))
 		}
 
 		err = QuicksilverFix(ctx, keepers)

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -17,6 +17,8 @@ import (
 )
 
 func FixBankMetadata(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	ctx.Logger().Info("Starting fix bank metadata...")
+
 	malformedDenom := "uatomu"
 	correctDenom := "uatom"
 
@@ -34,32 +36,36 @@ func FixBankMetadata(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 		// confirm whether the old key is still accessible
 		_, foundMalformed = keepers.BankKeeper.GetDenomMetaData(ctx, malformedDenom)
 		if foundMalformed {
-			return errors.New("malformed 'uatomu' denom not fixed")
+			return errors.New("Malformed 'uatomu' denom not fixed")
 		}
 	}
 
 	// proceed with the original intention of populating the missing Name and Symbol fields
 	atomMetaData, foundCorrect := keepers.BankKeeper.GetDenomMetaData(ctx, correctDenom)
 	if !foundCorrect {
-		return errors.New("atom denom not found")
+		return errors.New("Atom denom not found")
 	}
 
 	atomMetaData.Name = "Cosmos Hub Atom"
 	atomMetaData.Symbol = "ATOM"
 	keepers.BankKeeper.SetDenomMetaData(ctx, atomMetaData)
 
+	ctx.Logger().Info("Fix bank metadata complete")
+
 	return nil
 }
 
 func QuicksilverFix(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	ctx.Logger().Info("Starting fix quicksilver...")
+
 	// Refund stuck coins from ica address
 	sourceAddress, err := sdk.AccAddressFromBech32("cosmos13dqvh4qtg4gzczuktgnw8gc2ewnwmhdwnctekxctyr4azz4dcyysecgq7e")
 	if err != nil {
-		return errors.New("invalid source address")
+		return errors.New("Invalid source address")
 	}
 	destinationAddress, err := sdk.AccAddressFromBech32("cosmos1jc24kwznud9m3mwqmcz3xw33ndjuufnghstaag")
 	if err != nil {
-		return errors.New("invalid destination address")
+		return errors.New("Invalid destination address")
 	}
 
 	// Get balance from stuck address and subtract 1 uatom sent by bad actor
@@ -68,7 +74,7 @@ func QuicksilverFix(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 		refundBalance := sourceBalance.SubAmount(sdk.NewInt(1))
 		err = keepers.BankKeeper.SendCoins(ctx, sourceAddress, destinationAddress, sdk.NewCoins(refundBalance))
 		if err != nil {
-			return errors.New("unable to refund coins")
+			return errors.New("Unable to refund coins")
 		}
 	}
 
@@ -78,6 +84,8 @@ func QuicksilverFix(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 	closeChannel(keepers, ctx, "channel-464")
 	closeChannel(keepers, ctx, "channel-465")
 	closeChannel(keepers, ctx, "channel-466")
+
+	ctx.Logger().Info("Fix quicksilver complete")
 
 	return nil
 }
@@ -96,7 +104,7 @@ func CreateUpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		ctx.Logger().Info("running upgrade fixes...")
+		ctx.Logger().Info("Running upgrade fixes...")
 
 		err := FixBankMetadata(ctx, keepers)
 		if err != nil {
@@ -117,14 +125,14 @@ func CreateUpgradeHandler(
 		// Update params for host & controller keepers
 		keepers.ICAHostKeeper.SetParams(ctx, hostParams)
 
-		ctx.Logger().Info("start to run module migrations...")
+		ctx.Logger().Info("Starting module migrations...")
 
 		vm, err = mm.RunMigrations(ctx, configurator, vm)
 		if err != nil {
 			return vm, err
 		}
 
-		ctx.Logger().Info("upgrade complete")
+		ctx.Logger().Info("Upgrade complete")
 		return vm, err
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.14.0
-	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.0
+	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112194700-a2292dc067c9
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.24
 	github.com/tendermint/tm-db v0.6.7

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.14.0
-	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112194700-a2292dc067c9
+	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.24
 	github.com/tendermint/tm-db v0.6.7

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cosmos/gaia/v8
 go 1.18
 
 require (
-	github.com/cosmos/cosmos-sdk v0.45.11
+	github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v3 v3.4.0
 	github.com/gogo/protobuf v1.3.3
@@ -286,7 +286,7 @@ replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 
 	// enforce same SDK, Tendermint and IBC on all dependencies
-	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.45.11
+	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572
 	github.com/cosmos/ibc-go/v3 => github.com/cosmos/ibc-go/v3 v3.4.0
 
 	// use cosmos style protobufs

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.14.0
-	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.0
+	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.1-0.20230113180046-4fb516ae522e
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.24
 	github.com/tendermint/tm-db v0.6.7

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cosmos/gaia/v8
 go 1.18
 
 require (
-	github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572
+	github.com/cosmos/cosmos-sdk v0.45.11
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v3 v3.4.0
 	github.com/gogo/protobuf v1.3.3
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.14.0
+	// TODO: Revert to v3.0.0 once strangelove upgrade fix is merged
 	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.24
@@ -286,7 +287,7 @@ replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 
 	// enforce same SDK, Tendermint and IBC on all dependencies
-	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572
+	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.45.11
 	github.com/cosmos/ibc-go/v3 => github.com/cosmos/ibc-go/v3 v3.4.0
 
 	// use cosmos style protobufs

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.14.0
-	// TODO: Revert to v3.0.0 once strangelove upgrade fix is merged
-	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f
+	github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.24
 	github.com/tendermint/tm-db v0.6.7

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
-github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572 h1:7/+gN5a7qOcRhG9bKq4J9Ec45xuYIBf/IYdVI8dFWXQ=
-github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572/go.mod h1:45z8Q1Ah4iypFycu2Kl4kBPIsQKUiND8G2CUX+HTtPM=
+github.com/cosmos/cosmos-sdk v0.45.11 h1:Pc44fFEkai0KXFND5Ys/2ZJkfVdstMIBzKBN8MY7Ll0=
+github.com/cosmos/cosmos-sdk v0.45.11/go.mod h1:45z8Q1Ah4iypFycu2Kl4kBPIsQKUiND8G2CUX+HTtPM=
 github.com/cosmos/cosmos-sdk/ics23/go v0.8.0 h1:iKclrn3YEOwk4jQHT2ulgzuXyxmzmPczUalMwW4XH9k=
 github.com/cosmos/cosmos-sdk/ics23/go v0.8.0/go.mod h1:2a4dBq88TUoqoWAU5eu0lGvpFP3wWDPgdHPargtyw30=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=

--- a/go.sum
+++ b/go.sum
@@ -1094,8 +1094,8 @@ github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRk
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm07ysF0U6JQXczc=
 github.com/stbenjam/no-sprintf-host-port v0.1.1/go.mod h1:TLhvtIvONRzdmkFiio4O8LHsN9N74I+PhRquPsxpL0I=
-github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.0 h1:V1RVRa2hga4TV//RQpk2PCt314slS3N12024TsJoJUo=
-github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.0/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112194700-a2292dc067c9 h1:CjWYNyfTUYBM20GkTjTog+gb8vzNf1VBDuB9GVpFQwU=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112194700-a2292dc067c9/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/go.sum
+++ b/go.sum
@@ -1096,6 +1096,8 @@ github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm
 github.com/stbenjam/no-sprintf-host-port v0.1.1/go.mod h1:TLhvtIvONRzdmkFiio4O8LHsN9N74I+PhRquPsxpL0I=
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.0 h1:EeEeCAXbNhJtO8Q++C9ZSxLs+MjygsKRK7FiScNHe1E=
 github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.0/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.1-0.20230113180046-4fb516ae522e h1:qdK0r0xRSZjWTn5g6ORLKBZcQ/vyQxJC1vZTW9ogVl4=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.1-0.20230113180046-4fb516ae522e/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/go.sum
+++ b/go.sum
@@ -1094,8 +1094,8 @@ github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRk
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm07ysF0U6JQXczc=
 github.com/stbenjam/no-sprintf-host-port v0.1.1/go.mod h1:TLhvtIvONRzdmkFiio4O8LHsN9N74I+PhRquPsxpL0I=
-github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112194700-a2292dc067c9 h1:CjWYNyfTUYBM20GkTjTog+gb8vzNf1VBDuB9GVpFQwU=
-github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112194700-a2292dc067c9/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f h1:KPvPxRdC7JsonEQAhTN3ArIQQ3fYcBEjdB9cDH57OxA=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/go.sum
+++ b/go.sum
@@ -1094,8 +1094,8 @@ github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRk
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm07ysF0U6JQXczc=
 github.com/stbenjam/no-sprintf-host-port v0.1.1/go.mod h1:TLhvtIvONRzdmkFiio4O8LHsN9N74I+PhRquPsxpL0I=
-github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f h1:KPvPxRdC7JsonEQAhTN3ArIQQ3fYcBEjdB9cDH57OxA=
-github.com/strangelove-ventures/packet-forward-middleware/v3 v3.0.1-0.20230112214109-6867bcaac00f/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.0 h1:EeEeCAXbNhJtO8Q++C9ZSxLs+MjygsKRK7FiScNHe1E=
+github.com/strangelove-ventures/packet-forward-middleware/v3 v3.1.0/go.mod h1:sRBHb6KwuHQVc07vy8Ice9wUKVdvzn7eEms9scr2Zco=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
-github.com/cosmos/cosmos-sdk v0.45.11 h1:Pc44fFEkai0KXFND5Ys/2ZJkfVdstMIBzKBN8MY7Ll0=
-github.com/cosmos/cosmos-sdk v0.45.11/go.mod h1:45z8Q1Ah4iypFycu2Kl4kBPIsQKUiND8G2CUX+HTtPM=
+github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572 h1:7/+gN5a7qOcRhG9bKq4J9Ec45xuYIBf/IYdVI8dFWXQ=
+github.com/cosmos/cosmos-sdk v0.45.12-0.20230111125903-4163a1a01572/go.mod h1:45z8Q1Ah4iypFycu2Kl4kBPIsQKUiND8G2CUX+HTtPM=
 github.com/cosmos/cosmos-sdk/ics23/go v0.8.0 h1:iKclrn3YEOwk4jQHT2ulgzuXyxmzmPczUalMwW4XH9k=
 github.com/cosmos/cosmos-sdk/ics23/go v0.8.0/go.mod h1:2a4dBq88TUoqoWAU5eu0lGvpFP3wWDPgdHPargtyw30=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=


### PR DESCRIPTION
During the course of simulated upgrade testing with exported genesis from mainnet it was discovered that the node would panic after upgrading when attempting to prune two different stores, icacontroller and packetforwardmiddleware (PFM).

**Update**:  The fix for ica controller is to remove this as it was accidentally leftover as an artifact from the original v8 release with `v0.46` of the sdk. For PFM, the fix includes a corrected wiring in Gaia, and several updates to PFM itself due to an incorrectly named module and incorrect implementation of an interface necessary to pass to the TransferKeeper.