### PR TITLE
refactor: pass routerKeeper to appKeeper as a pointer

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -91,7 +91,7 @@ type AppKeepers struct {
 	AuthzKeeper     authzkeeper.Keeper
 	LiquidityKeeper liquiditykeeper.Keeper
 
-	RouterKeeper routerkeeper.Keeper
+	RouterKeeper *routerkeeper.Keeper
 
 	// Modules
 	ICAModule      ica.AppModule
@@ -273,7 +273,7 @@ func NewAppKeeper(
 	)
 
 	// RouterKeeper must be created before TransferKeeper
-	appKeepers.RouterKeeper = *routerkeeper.NewKeeper(
+	appKeepers.RouterKeeper = routerkeeper.NewKeeper(
 		appCodec, appKeepers.keys[routertypes.StoreKey],
 		appKeepers.GetSubspace(routertypes.ModuleName),
 		appKeepers.TransferKeeper,
@@ -288,7 +288,7 @@ func NewAppKeeper(
 		appCodec,
 		appKeepers.keys[ibctransfertypes.StoreKey],
 		appKeepers.GetSubspace(ibctransfertypes.ModuleName),
-		&appKeepers.RouterKeeper,
+		appKeepers.RouterKeeper,
 		appKeepers.IBCKeeper.ChannelKeeper,
 		&appKeepers.IBCKeeper.PortKeeper,
 		appKeepers.AccountKeeper,
@@ -313,13 +313,13 @@ func NewAppKeeper(
 	appKeepers.ICAModule = ica.NewAppModule(nil, &appKeepers.ICAHostKeeper)
 	icaHostIBCModule := icahost.NewIBCModule(appKeepers.ICAHostKeeper)
 
-	appKeepers.RouterModule = router.NewAppModule(&appKeepers.RouterKeeper)
+	appKeepers.RouterModule = router.NewAppModule(appKeepers.RouterKeeper)
 
 	var ibcStack porttypes.IBCModule
 	ibcStack = transfer.NewIBCModule(appKeepers.TransferKeeper)
 	ibcStack = router.NewIBCMiddleware(
 		ibcStack,
-		&appKeepers.RouterKeeper,
+		appKeepers.RouterKeeper,
 		0,
 		routerkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
 		routerkeeper.DefaultRefundTransferPacketTimeoutTimestamp,


### PR DESCRIPTION
Regarding to https://github.com/cosmos/gaia/pull/2028, since now we use only `routerKeeper` pointer, we can pass `routerKeepr` as a pointer to `appKeeper`. This is similar how `IBCkeeper` integrated.