### PR TITLE
chore: add rc tag to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: create release
 on:
     push:
         tags:
-            - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+            - "v[0-9]+\\.[0-9]+\\.[0-9]+"
+            - "v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+"
 
 jobs:
     build:


### PR DESCRIPTION
Presently, when we tag a release, the building and uploading the artifacts will be trigger by this release.yml action.
but this does not work for rc release, this pr add the rc release to trigger the action.