### PR TITLE
fix: global fee

### DIFF
--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -70,7 +70,7 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 	var allFees sdk.Coins
 	requiredGlobalFees, err := mfd.getGlobalFee(ctx, feeTx)
 	if err != nil {
-		panic(err)
+		return ctx, err
 	}
 	requiredFees := getMinGasPrice(ctx, feeTx)
 

--- a/x/globalfee/ante/fee_utils.go
+++ b/x/globalfee/ante/fee_utils.go
@@ -1,8 +1,6 @@
 package ante
 
 import (
-	"math"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmstrings "github.com/tendermint/tendermint/libs/strings"
 )
@@ -144,23 +142,6 @@ func CombinedFeeRequirement(globalFees, minGasPrices sdk.Coins) sdk.Coins {
 	}
 
 	return allFees.Sort()
-}
-
-// getTxPriority returns a naive tx priority based on the amount of the smallest denomination of the fee
-// provided in a transaction.
-func GetTxPriority(fee sdk.Coins) int64 {
-	var priority int64
-	for _, c := range fee {
-		p := int64(math.MaxInt64)
-		if c.Amount.IsInt64() {
-			p = c.Amount.Int64()
-		}
-		if priority == 0 || p < priority {
-			priority = p
-		}
-	}
-
-	return priority
 }
 
 // Find replaces the functionality of Coins.Find from SDK v0.46.x


### PR DESCRIPTION
- In global fee, there are two panics which should not panic, but return.
Currently, This will not panic due to a wrong denom will already panic early when parsing the coins from the flag. But this might cause potential problems.
- remove legacy code which was used when bumping to sdk 0.46