### PR TITLE
feat: Add go version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
 TEST_DOCKER_REPO=cosmos/contrib-gaiatest
 
-GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
-GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
+GO_SYSTEM_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1-2)
+REQUIRE_GO_VERSION = 1.18
 
 export GO111MODULE = on
 
@@ -96,7 +96,7 @@ include contrib/devtools/Makefile
 ###############################################################################
 
 check_version:
-ifneq ($(GO_MINOR_VERSION),18)
+ifneq ($(GO_SYSTEM_VERSION), $(REQUIRE_GO_VERSION))
 	@echo "ERROR: Go version 1.18 is required for $(VERSION) of Gaia."
 	exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
 TEST_DOCKER_REPO=cosmos/contrib-gaiatest
 
+GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
+GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
+
 export GO111MODULE = on
 
 # process build tags
@@ -89,8 +92,14 @@ endif
 include contrib/devtools/Makefile
 
 ###############################################################################
-###                              Documentation                              ###
+###                              Build                                      ###
 ###############################################################################
+
+check_version:
+ifneq ($(GO_MINOR_VERSION),18)
+	@echo "ERROR: Go version 1.18 is required for $(VERSION) of Gaia."
+	exit 1
+endif
 
 all: install lint run-tests test-e2e vulncheck
 
@@ -98,7 +107,7 @@ BUILD_TARGETS := build install
 
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
-$(BUILD_TARGETS): go.sum $(BUILDDIR)/
+$(BUILD_TARGETS): check_version go.sum $(BUILDDIR)/
 	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 
 $(BUILDDIR)/:


### PR DESCRIPTION
This PR addresses concerns raised in #2016 by adding a check in the Makefile to ensure the system is using `1.18` to build Gaia. 

AC
```
$ go version
go version go1.19.5 darwin/arm64

$ make build
ERROR: Go version 1.18 is required for glnro/version-warning-983a9fe4288d6e474aea7402afc640fcbc67e842 of Gaia.
exit 1
make: *** [check_version] Error 1

// Downgrade to 1.18

$ go version
go version go1.18.10 darwin/arm64

$ make build
--> Ensure dependencies have not been modified
all modules verified
...
```