### PR TITLE
Bump ics to rc4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.11
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v4 v4.2.0
-	github.com/cosmos/interchain-security v1.0.0-rc3
+	github.com/cosmos/interchain-security v1.0.0-rc4
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/golangci/golangci-lint v1.50.1
@@ -297,7 +297,7 @@ replace (
 	github.com/cosmos/ibc-go/v4 => github.com/cosmos/ibc-go/v4 v4.2.0
 
 	// ICS
-	github.com/cosmos/interchain-security => github.com/cosmos/interchain-security v1.0.0-rc3
+	github.com/cosmos/interchain-security => github.com/cosmos/interchain-security v1.0.0-rc4
 
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -746,8 +746,8 @@ github.com/cosmos/iavl v0.19.4/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONAp
 github.com/cosmos/ibc-go v1.2.2/go.mod h1:XmYjsRFOs6Q9Cz+CSsX21icNoH27vQKb3squgnCOCbs=
 github.com/cosmos/ibc-go/v4 v4.2.0 h1:Fx/kKq/uvawrAxk6ZrQ6sEIgffLRU5Cs/AUnvpPBrHI=
 github.com/cosmos/ibc-go/v4 v4.2.0/go.mod h1:57qWScDtfCx3FOMLYmBIKPbOLE6xiVhrgxHAQmbWYXM=
-github.com/cosmos/interchain-security v1.0.0-rc3 h1:DsrDvQYkwrOE1bzMXCOSp77csRE4h27HLLhVIMjJ8DQ=
-github.com/cosmos/interchain-security v1.0.0-rc3/go.mod h1:D6Js3PwY0SYWgFoJvaRgAGLq7cZyqpLdQPEXeCwtlls=
+github.com/cosmos/interchain-security v1.0.0-rc4 h1:8baTeUYYUs+AI3r9cqhhZmI/ekERcHvCiH4GuJhpTZ8=
+github.com/cosmos/interchain-security v1.0.0-rc4/go.mod h1:D6Js3PwY0SYWgFoJvaRgAGLq7cZyqpLdQPEXeCwtlls=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=


### PR DESCRIPTION
Version bump ics to [v1.0.0 rc4](https://github.com/cosmos/interchain-security/releases/tag/v1.0.0-rc4), which has a [critical fix](https://github.com/cosmos/interchain-security/pull/687)