### PR TITLE
docs: Removed Stargazer explorer, now depreciated

### DIFF
--- a/docs/hub-overview/overview.md
+++ b/docs/hub-overview/overview.md
@@ -54,7 +54,6 @@ These block explorers allow you to search, view and analyze Cosmos Hub data&mdas
 * [LOOK Explorer](https://cosmos.ping.pub)
 * [Lunie](https://lunie.io)
 * [Mintscan](https://mintscan.io)
-* [Stargazer](https://stargazer.certus.one)
 * [Union Market](https://union.market/token/cosmos)
 
 ## Cosmos Hub CLI


### PR DESCRIPTION
Explorer now depreciated see press release on [way-back-machine](https://web.archive.org/web/20230117140559/https://stargazer.certus.one/)