### PR TITLE
chore: bump ics to rc-7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -302,7 +302,7 @@ replace (
 	github.com/cosmos/ibc-go/v4 => github.com/cosmos/ibc-go/v4 v4.2.0
 
 	// ICS
-	github.com/cosmos/interchain-security => github.com/cosmos/interchain-security v1.0.0-rc6
+	github.com/cosmos/interchain-security => github.com/cosmos/interchain-security v1.0.0-rc7
 
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/cosmos/iavl v0.19.5/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONAp
 github.com/cosmos/ibc-go v1.2.2/go.mod h1:XmYjsRFOs6Q9Cz+CSsX21icNoH27vQKb3squgnCOCbs=
 github.com/cosmos/ibc-go/v4 v4.2.0 h1:Fx/kKq/uvawrAxk6ZrQ6sEIgffLRU5Cs/AUnvpPBrHI=
 github.com/cosmos/ibc-go/v4 v4.2.0/go.mod h1:57qWScDtfCx3FOMLYmBIKPbOLE6xiVhrgxHAQmbWYXM=
-github.com/cosmos/interchain-security v1.0.0-rc6 h1:LRPWfjCTrINTUcbnVSBcTpbnJg7R5cq/q4AhNc26WcM=
-github.com/cosmos/interchain-security v1.0.0-rc6/go.mod h1:J9SbXUJT1GSe+mZy+MDCxtuAfbhwCKBEJRYnfjXsE8Q=
+github.com/cosmos/interchain-security v1.0.0-rc7 h1:OZ4qUJz8pTkb4pneu4O8pBNWy2GsP9ycmrrybxYAglk=
+github.com/cosmos/interchain-security v1.0.0-rc7/go.mod h1:J9SbXUJT1GSe+mZy+MDCxtuAfbhwCKBEJRYnfjXsE8Q=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/cosmos/ledger-cosmos-go v0.12.2 h1:/XYaBlE2BJxtvpkHiBm97gFGSGmYGKunKyF3nNqAXZA=


### PR DESCRIPTION
See https://github.com/cosmos/interchain-security/releases/tag/v1.0.0-rc7