### PR TITLE
Fix missing equivocation prop

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -89,6 +89,7 @@ var ModuleBasics = module.NewBasicManager(
 		ibcclientclient.UpgradeProposalHandler,
 		ibcproviderclient.ConsumerAdditionProposalHandler,
 		ibcproviderclient.ConsumerRemovalProposalHandler,
+		ibcproviderclient.EquivocationProposalHandler,
 	),
 	params.AppModuleBasic{},
 	crisis.AppModuleBasic{},


### PR DESCRIPTION
This PR updates gaia to include the equivocation gov proposal that was [added in RC7 of ICS](https://github.com/cosmos/gaia/pull/2174). 