### PR TITLE
update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,32 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    labels:
+      - "A:automerge"
+      - dependencies
   - package-ecosystem: npm
     directory: "/docs"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    reviewers:
-      - fadeev
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "A:automerge"
       - dependencies
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "release/v9.0.x"
+    # Only allow automated security-related dependency updates on release branches.
+    open-pull-requests-limit: 0
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "release/v8.0.x"
+    # Only allow automated security-related dependency updates on release branches.
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
     labels:
       - "A:automerge"
 
-  - package-ecosystem: npm
-    directory: "/docs"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    labels:
-      - "A:automerge"
-
   - package-ecosystem: gomod
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,16 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - "A:automerge"
 
   - package-ecosystem: npm
     directory: "/docs"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - "A:automerge"
 
   - package-ecosystem: gomod
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,23 +3,24 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - "A:automerge"
       - dependencies
-  - package-ecosystem: npm
-    directory: "/docs"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
+
   - package-ecosystem: gomod
     directory: "/"
     schedule:
@@ -27,6 +28,9 @@ updates:
     target-branch: "release/v9.0.x"
     # Only allow automated security-related dependency updates on release branches.
     open-pull-requests-limit: 0
+    labels:
+      - dependencies
+
   - package-ecosystem: gomod
     directory: "/"
     schedule:
@@ -34,3 +38,5 @@ updates:
     target-branch: "release/v8.0.x"
     # Only allow automated security-related dependency updates on release branches.
     open-pull-requests-limit: 0
+    labels:
+      - dependencies


### PR DESCRIPTION
closes: #2268

This PR udpates the dependabot.yml.
- update github-action packages with label auto-merge, PR against main branch
- update gomod packages, PR against main branch
- update gomod packages for security fix, PR against release/v9.0.x and release/v8.0.x

@mmulji-ic, please check [here](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories) for admin to setup dependabot security updates for github repo. Thanks!