### PR TITLE
Update Codeowners to remove Hypha for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 *       @alexanderbez @zmanian @yaruwangway @crodriguezvega @jackzampolin @mmulji-ic @glnro @jtremback @mpoke @sainoe @MSalopek @smarshall-spitzbart
 
 # Governance Process and Docs maintainers
-docs/governance/*       @uditvira @LexaMichaelides @yaruwangway
+docs/governance/*       @yaruwangway @mmulji-ic @mpoke
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 *       @alexanderbez @zmanian @yaruwangway @crodriguezvega @jackzampolin @mmulji-ic @glnro @jtremback @mpoke @sainoe @MSalopek @smarshall-spitzbart
 
 # Governance Process and Docs maintainers
-docs/governance/*       @yaruwangway @mmulji-ic @mpoke
+docs/governance/*       @jtremback @mmulji-ic @mpoke
 


### PR DESCRIPTION
Removed Hypha docs maintainers from codeowners.
Hypha will be focusing on testnet related work and will not work actively on docs.