### PR TITLE
update hermes version for e2e tests

### DIFF
--- a/tests/e2e/docker/hermes.Dockerfile
+++ b/tests/e2e/docker/hermes.Dockerfile
@@ -1,4 +1,4 @@
-FROM informalsystems/hermes:1.0.0 AS hermes-builder
+FROM informalsystems/hermes:1.3.0 AS hermes-builder
 
 FROM debian:buster-slim
 USER root


### PR DESCRIPTION
This PR updates hermes version from `v1.0.0` to `v1.3.0` in gaia e2e test suite.

Closes: #2245 