### PR TITLE
Update tutorial examples on minting

### DIFF
--- a/docs/hub-tutorials/gaiad.md
+++ b/docs/hub-tutorials/gaiad.md
@@ -374,19 +374,19 @@ gaiad query slashing params
 You can query for the minting/inflation parameters via:
 
 ```bash
-gaiad query minting params
+gaiad query mint params
 ```
 
 To query for the current inflation value:
 
 ```bash
-gaiad query minting inflation
+gaiad query mint inflation
 ```
 
 To query for the current annual provisions value:
 
 ```bash
-gaiad query minting annual-provisions
+gaiad query mint annual-provisions
 ```
 
 ### Staking

--- a/docs/ko/resources/gaiad.md
+++ b/docs/ko/resources/gaiad.md
@@ -322,19 +322,19 @@ gaiad query slashing params
 민팅/인플레이션 파라미터 값은 다음과 같이 조회하실 수 있습니다:
 
 ```bash
-gaiad query minting params
+gaiad query mint params
 ```
 
 현재 인플레이션 값은 다음과 같이 조회하실 수 있습니다:
 
 ```bash
-gaiad query minting inflation
+gaiad query mint inflation
 ```
 
 현재 프로비젼(provisions) 값은 다음과 같이 조회하실 수 있습니다:
 
 ```bash
-gaiad query minting annual-provisions
+gaiad query mint annual-provisions
 ```
 
 ### 스테이킹


### PR DESCRIPTION
I noticed that the `minting` CLI namespace is `mint` in the latest released version (`v9.0.1`). Opening a PR to update the tutorial examples accordingly. Thanks!