### PR TITLE
docs: Removed trust node in docs

### DIFF
--- a/docs/hub-tutorials/gaiad.md
+++ b/docs/hub-tutorials/gaiad.md
@@ -29,14 +29,6 @@ gaiad config node <host>:<port>
 
 If you run your own full-node, just use `tcp://localhost:26657` as the address.
 
-Then, let us set the default value of the `--trust-node` flag:
-
-```bash
-gaiad config trust-node true
-
-# Set to true if you trust the full-node you are connecting to, false otherwise
-```
-
 Finally, let us set the `chain-id` of the blockchain we want to interact with:
 
 ```bash

--- a/docs/hub-tutorials/live-upgrade-tutorial.md
+++ b/docs/hub-tutorials/live-upgrade-tutorial.md
@@ -15,7 +15,6 @@ governance process.
    $ gaiad start
 
    # set up the cli config
-   $ gaiad config trust-node true
    $ gaiad config chain-id testing
 
    # create an upgrade governance proposal


### PR DESCRIPTION
The trust node command was removed from the SDK and the docs were not updated. This PR removes the command from the docs.

Fixes #2344 