### PR TITLE
fix docker image urls for e2e tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache $PACKAGES
 RUN CGO_ENABLED=0 make install
 
 # Add to a distroless container
-FROM distroless.dev/static:$IMG_TAG
+FROM cgr.dev/chainguard/static:$IMG_TAG
 ARG IMG_TAG
 COPY --from=gaiad-builder /go/bin/gaiad /usr/local/bin/
 EXPOSE 26656 26657 1317 9090

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache $PACKAGES
 RUN CGO_ENABLED=0 make install
 
 # Add to a distroless container
-FROM distroless.dev/static:$IMG_TAG
+FROM cgr.dev/chainguard/static:$IMG_TAG
 ARG IMG_TAG
 COPY --from=gaiad-builder /go/bin/gaiad /usr/local/bin/
 EXPOSE 26656 26657 1317 9090


### PR DESCRIPTION
closes: https://github.com/cosmos/gaia/issues/2370

Update the broken Distroless docker image URLs in the Dockerfiles.