### PR TITLE
Fix bug in tests breaking the linter

### DIFF
--- a/x/globalfee/ante/fee_utils.go
+++ b/x/globalfee/ante/fee_utils.go
@@ -77,7 +77,9 @@ func Find(coins sdk.Coins, denom string) (bool, sdk.Coin) {
 
 // splitCoinsByDenoms returns the given coins split in two whether
 // their demon is or isn't found in the given denom map.
-func splitCoinsByDenoms(feeCoins sdk.Coins, denomMap map[string]bool) (feeCoinsNonZeroDenom sdk.Coins, feeCoinsZeroDenom sdk.Coins) {
+func splitCoinsByDenoms(feeCoins sdk.Coins, denomMap map[string]bool) (sdk.Coins, sdk.Coins) {
+	feeCoinsNonZeroDenom, feeCoinsZeroDenom := sdk.Coins{}, sdk.Coins{}
+
 	for _, fc := range feeCoins {
 		_, found := denomMap[fc.Denom]
 		if found {

--- a/x/globalfee/ante/fee_utils_test.go
+++ b/x/globalfee/ante/fee_utils_test.go
@@ -270,7 +270,7 @@ func TestSplitGlobalFees(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			nonZeroCoins, zeroCoinsMap := splitFees(test.globalfees)
+			nonZeroCoins, zeroCoinsMap := getNonZeroFees(test.globalfees)
 			require.True(t, nonZeroCoins.IsEqual(test.globalfeesNonZero))
 			require.True(t, equalMap(zeroCoinsMap, test.zeroGlobalFeesDenom))
 		})


### PR DESCRIPTION
 PR #2351 contained a misnamed method call in a test that was causing the linter and UTs to fail. 