### PR TITLE
enforce the use of go 1.20, making mixed runtimes impossible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
 TEST_DOCKER_REPO=cosmos/contrib-gaiatest
 
-GO_SYSTEM_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1-2)
-REQUIRE_GO_VERSION = 1.18
 
 export GO111MODULE = on
 
@@ -95,11 +93,6 @@ include contrib/devtools/Makefile
 ###                              Build                                      ###
 ###############################################################################
 
-check_version:
-ifneq ($(GO_SYSTEM_VERSION), $(REQUIRE_GO_VERSION))
-	@echo "ERROR: Go version 1.18 is required for $(VERSION) of Gaia."
-	exit 1
-endif
 
 all: install lint run-tests test-e2e vulncheck
 
@@ -107,7 +100,7 @@ BUILD_TARGETS := build install
 
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
-$(BUILD_TARGETS): check_version go.sum $(BUILDDIR)/
+$(BUILD_TARGETS): go.sum $(BUILDDIR)/
 	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 
 $(BUILDDIR)/:

--- a/cmd/gaiad/cmd/lockgoversion.go
+++ b/cmd/gaiad/cmd/lockgoversion.go
@@ -1,0 +1,9 @@
+package cmd
+
+import (
+	"crypto/ecdh"
+)
+
+type lockGoVersion struct {
+	ecdh ecdh.Curve
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/gaia/v9
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cosmos/cosmos-sdk v0.45.15-ics


### PR DESCRIPTION
THis PR makes it impossible to use any version of Go below 1.20 with Gaia. 

Go has a builtin install command like:

```bash
go install ./...
```

many validators use it.  It fully bypasses the go version check in Makefile.
