### PR TITLE
fix: globalfee subspace

### DIFF
--- a/x/globalfee/migrations/v2/migration.go
+++ b/x/globalfee/migrations/v2/migration.go
@@ -28,7 +28,7 @@ func MigrateStore(ctx sdk.Context, globalfeeSubspace paramtypes.Subspace) error 
 	}
 
 	if !globalfeeSubspace.HasKeyTable() {
-		globalfeeSubspace.WithKeyTable(types.ParamKeyTable())
+		globalfeeSubspace = globalfeeSubspace.WithKeyTable(types.ParamKeyTable())
 	}
 
 	globalfeeSubspace.SetParamSet(ctx, &params)

--- a/x/globalfee/migrations/v2/v2_test/migration_test.go
+++ b/x/globalfee/migrations/v2/v2_test/migration_test.go
@@ -41,8 +41,8 @@ func TestMigrateStore(t *testing.T) {
 		memStoreKey,
 		paramtypes.ModuleName,
 	)
-	// register the subspace withthe v10 paramKeyTable
-	newSubspace.WithKeyTable(globalfeetypes.ParamKeyTable())
+	// register the subspace with the v10 paramKeyTable
+	newSubspace = newSubspace.WithKeyTable(globalfeetypes.ParamKeyTable())
 
 	// check MinGasPrices isn't set
 	_, ok := getMinGasPrice(newSubspace, ctx)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

The `subspace.WithKeyTable` will return a new subspace rather than change the original one. 
The migration is working because `globalfeeSubspace.SetParamSet(ctx, &params)` does not need the keyTable to be set, it will use the validationFn from &params when setting params, `subspace.set()` will require KeyTable to be set. The code is redundant, but extra check is more secure. so i fixed the code rather than delete it.
```
	if !globalfeeSubspace.HasKeyTable() {
		globalfeeSubspace = globalfeeSubspace.WithKeyTable(types.ParamKeyTable())
	}
```


thank you for the comment @smarshall-spitzbart 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Pull requests that sit inactive for longer than 14 days will be closed.  -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if API or client breaking change
* [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
