### PR TITLE
test: parsing result of query hermes pending packets

### DIFF
--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -617,7 +617,7 @@ func (s *IntegrationTestSuite) executeGaiaTxCommand(ctx context.Context, c *chai
 	}
 }
 
-func (s *IntegrationTestSuite) executeHermesCommand(ctx context.Context, hermesCmd []string) (string, string) {
+func (s *IntegrationTestSuite) executeHermesCommand(ctx context.Context, hermesCmd []string) ([]byte, []byte) {
 	var (
 		outBuf bytes.Buffer
 		errBuf bytes.Buffer
@@ -643,7 +643,7 @@ func (s *IntegrationTestSuite) executeHermesCommand(ctx context.Context, hermesC
 	stdOut := outBuf.Bytes()
 	stdErr := errBuf.Bytes()
 
-	return string(stdOut), string(stdErr)
+	return stdOut, stdErr
 }
 
 func (s *IntegrationTestSuite) expectErrExecValidation(chain *chain, valIdx int, expectErr bool) func([]byte, []byte) bool {

--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -76,14 +76,14 @@ func (s *IntegrationTestSuite) hermesTransfer(configPath, srcChainID, dstChainID
 	}
 
 	stdout, stderr := s.executeHermesCommand(ctx, hermesCmd)
-	if strings.Contains(stdout, "ERROR") || strings.Contains(stderr, "ERROR") {
+	if strings.Contains(string(stdout), "ERROR") || strings.Contains(string(stderr), "ERROR") {
 		return false
 	}
 
 	return true
 }
 
-func (s *IntegrationTestSuite) hermesClearPacket(configPath, chainID, channelID string) bool { //nolint:unparam
+func (s *IntegrationTestSuite) hermesClearPacket(configPath, chainID, channelID string) (success bool) { //nolint:unparam
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -98,11 +98,23 @@ func (s *IntegrationTestSuite) hermesClearPacket(configPath, chainID, channelID 
 	}
 
 	stdout, stderr := s.executeHermesCommand(ctx, hermesCmd)
-	if strings.Contains(stdout, "ERROR") || strings.Contains(stderr, "ERROR") {
+	if strings.Contains(string(stdout), "ERROR") || strings.Contains(string(stderr), "ERROR") {
 		return false
 	}
 
 	return true
+}
+
+type Response struct {
+	Result struct {
+		Dst struct {
+			UnreceivedPackets []interface{} `json:"unreceived_packets"`
+		} `json:"dst"`
+		Src struct {
+			UnreceivedPackets []interface{} `json:"unreceived_packets"`
+		} `json:"src"`
+	} `json:"result"`
+	Status string `json:"status"`
 }
 
 func (s *IntegrationTestSuite) hermesPendingPackets(configPath, chainID, channelID string) (pendingPackets bool) {
@@ -110,6 +122,7 @@ func (s *IntegrationTestSuite) hermesPendingPackets(configPath, chainID, channel
 	defer cancel()
 	hermesCmd := []string{
 		hermesBinary,
+		"--json",
 		fmt.Sprintf("--config=%s", configPath),
 		"query",
 		"packet",
@@ -120,12 +133,13 @@ func (s *IntegrationTestSuite) hermesPendingPackets(configPath, chainID, channel
 	}
 
 	stdout, _ := s.executeHermesCommand(ctx, hermesCmd)
-	stdout = strings.ReplaceAll(stdout, " ", "")
-	stdout = strings.ReplaceAll(stdout, "\n", "")
-	stdout = strings.ToLower(stdout)
+
+	var response Response
+	err := json.Unmarshal(stdout, &response)
+	s.Require().NoError(err)
 
 	// Check if "unreceived_packets" exists in "src"
-	return !strings.Contains(stdout, "src:pendingpackets{unreceived_packets:[]")
+	return len(response.Result.Src.UnreceivedPackets) != 0
 }
 
 func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin) {

--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -105,7 +105,7 @@ func (s *IntegrationTestSuite) hermesClearPacket(configPath, chainID, channelID 
 	return true
 }
 
-type Response struct {
+type RelayerPacketsOutput struct {
 	Result struct {
 		Dst struct {
 			UnreceivedPackets []interface{} `json:"unreceived_packets"`
@@ -134,12 +134,12 @@ func (s *IntegrationTestSuite) hermesPendingPackets(configPath, chainID, channel
 
 	stdout, _ := s.executeHermesCommand(ctx, hermesCmd)
 
-	var response Response
-	err := json.Unmarshal(stdout, &response)
+	var relayerPacketsOutput RelayerPacketsOutput
+	err := json.Unmarshal(stdout, &relayerPacketsOutput)
 	s.Require().NoError(err)
 
 	// Check if "unreceived_packets" exists in "src"
-	return len(response.Result.Src.UnreceivedPackets) != 0
+	return len(relayerPacketsOutput.Result.Src.UnreceivedPackets) != 0
 }
 
 func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin) {

--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -122,9 +122,10 @@ func (s *IntegrationTestSuite) hermesPendingPackets(configPath, chainID, channel
 	stdout, _ := s.executeHermesCommand(ctx, hermesCmd)
 	stdout = strings.ReplaceAll(stdout, " ", "")
 	stdout = strings.ReplaceAll(stdout, "\n", "")
+	stdout = strings.ToLower(stdout)
 
 	// Check if "unreceived_packets" exists in "src"
-	return !strings.Contains(stdout, "src:pendingPackets{unreceived_packets:[]")
+	return !strings.Contains(stdout, "src:pendingpackets{unreceived_packets:[]")
 }
 
 func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin) {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=others.md
-->
closes: https://github.com/cosmos/gaia/issues/2486
## Description

`hermesPendingPackets` will get the pending packets result:
```
SUCCESS Summary {
    src: PendingPackets {
        unreceived_packets: [],
        unreceived_acks: [],
    },
    dst: PendingPackets {
        unreceived_packets: [],
        unreceived_acks: [],
    },
}
```
~~In order to check if there is pending packets, the  '\n' and ' ' are removed from result.
 `pending packet: SUCCESSSummary{src:PendingPackets{unreceived_packets:[],unreceived_packets:[],},dst:PendingPackets{unreceived_packets:[],unreceived_packets:[],},}`~~

~~If the result contains substr "src:Pendingpackets{unreceived_packets:[]", there is not pending packets. In order to not worry about the casing, we can convert the result to all lower case.~~

~~The failure of the e2e test is from looking for the wrong substring(wrong casing): "src:pendingPackets{unreceived_packets:[]" in the query result.~~
`hermesPendingPackets`  with --json will get json
```
{"result":{"dst":{"unreceived_acks":[],"unreceived_packets":[]},"src":{"unreceived_acks":[],"unreceived_packets":[]}},"status":"success"}
```
update `executeHermesCommand` with adding `--json` and parsing the json result to get  `unreceived_packets: []`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Pull requests that sit inactive for longer than 14 days will be closed.  -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if API or client breaking change
* [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
