### PR TITLE
docs: Add type prefix link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,8 +176,9 @@ Then:
 4. Be sure to include a relevant changelog entry in the `Unreleased` section of `CHANGELOG.md` (see file for log format). The entry should be on top of all others changes in the section.
 
 PRs must have a category prefix that is based on the type of changes being made (for example, `fix`, `feat`,
-`refactor`, `docs`, and so on). The *type* must be included in the PR title as a prefix (for example,
-`fix: <description>`). This convention ensures that all changes that are committed to the base branch follow the
+`refactor`, `docs`, and so on). The [type](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) 
+must be included in the PR title as a prefix (for example, `fix: <description>`). 
+This convention ensures that all changes that are committed to the base branch follow the
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 Additionally, **each PR should only address a single issue**.
 


### PR DESCRIPTION
## Description

Closes: NA

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Add type prefix link to CONTRIBUTING.md

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

