### PR TITLE
fix: app: make SimGenesisAccount.Validate error if .BaseAccount is nil

### DIFF
--- a/app/genesis_account.go
+++ b/app/genesis_account.go
@@ -43,5 +43,9 @@ func (sga SimGenesisAccount) Validate() error {
 		}
 	}
 
+	if sga.BaseAccount == nil {
+		return errors.New("BaseAccount must not be nil")
+	}
+
 	return sga.BaseAccount.Validate()
 }

--- a/app/genesis_account_fuzz_test.go
+++ b/app/genesis_account_fuzz_test.go
@@ -1,0 +1,35 @@
+package gaia
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/google/gofuzz"
+)
+
+func TestFuzzGenesisAccountValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("running in -short mode")
+	}
+
+	t.Parallel()
+
+	acct := new(SimGenesisAccount)
+	i := 0
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		// Otherwise report on the configuration and iteration.
+		t.Fatalf("Failed SimGenesisAccount on iteration #%d: %#v\n\n%s\n\n%s", i, acct, r, debug.Stack())
+	}()
+
+	f := fuzz.New()
+	for i = 0; i < 1e5; i++ {
+		acct = new(SimGenesisAccount)
+		f.Fuzz(acct)
+		acct.Validate()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.3
 	github.com/golangci/golangci-lint v1.52.2
+	github.com/google/gofuzz v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gravity-devs/liquidity v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0


### PR DESCRIPTION
This change ensures that an error is returned, instead of panicking, when SimGenesisAccount.BaseAccount is nil, after invoking .Validate. Found by fuzzing and added the tests in here to catch future regressions.

Fixes #2586

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage