### PR TITLE
IAVL fast node demonstration branch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - depguard
     - dogsled
     - errcheck
     - exportloopref
@@ -30,25 +29,25 @@ linters:
 
 issues:
   exclude-rules:
-    - text: "Use of weak random number generator"
+    - text: 'Use of weak random number generator'
       linters:
         - gosec
-    - text: "comment on exported var"
+    - text: 'comment on exported var'
       linters:
         - golint
     - text: "don't use an underscore in package name"
       linters:
         - golint
-    - text: "ST1003:"
+    - text: 'ST1003:'
       linters:
         - stylecheck
     # FIXME: Disabled until golangci-lint updates stylecheck with this fix:
     # https://github.com/dominikh/go-tools/issues/389
-    - text: "ST1016:"
+    - text: 'ST1016:'
       linters:
         - stylecheck
-    - path: "migrations"
-      text: "SA1019:"
+    - path: 'migrations'
+      text: 'SA1019:'
       linters:
         - staticcheck
 
@@ -66,3 +65,31 @@ linters-settings:
     allow-leading-space: true
     require-explanation: false
     require-specific: false
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: unused-parameter
+        disabled: true
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unreachable-code
+      - name: redefines-builtin-id

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ docker-build-all: docker-build-debug docker-build-hermes
 ###                                Linting                                  ###
 ###############################################################################
 golangci_lint_cmd=golangci-lint
-golangci_version=v1.50.1
+golangci_version=v1.53.1
 
 lint:
 	@echo "--> Running linter"

--- a/contrib/statesync.bash
+++ b/contrib/statesync.bash
@@ -9,6 +9,7 @@ export PATH=$PATH:~/go/bin
 # Install Gaia.
 make install
 
+
 # NOTE: ABOVE YOU CAN USE ALTERNATIVE DATABASES, HERE ARE THE EXACT COMMANDS
 # go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb' -tags rocksdb ./...
 # go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=badgerdb' -tags badgerdb ./...
@@ -20,14 +21,12 @@ make install
 # Initialize chain.
 gaiad init test --chain-id cosmoshub-4
 
-# Set minimum gas price.
-sed -i'' 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uatom"/' $HOME/.gaia/config/app.toml
 
 # Get "trust_hash" and "trust_height".
 INTERVAL=1000
-LATEST_HEIGHT=$(curl -s https://rpc.cosmos.network/block | jq -r .result.block.header.height)
+LATEST_HEIGHT=$(curl -s https://cached-rpc-cosmos.sg1.online/block | jq -r .result.block.header.height)
 BLOCK_HEIGHT=$(($LATEST_HEIGHT-$INTERVAL)) 
-TRUST_HASH=$(curl -s "https://rpc.cosmos.network/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)
+TRUST_HASH=$(curl -s "https://cached-rpc-cosmos.sg1.online/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)
 
 # Print out block and transaction hash from which to sync state.
 echo "trust_height: $BLOCK_HEIGHT"
@@ -36,7 +35,7 @@ echo "trust_hash: $TRUST_HASH"
 # Export state sync variables.
 export GAIAD_STATESYNC_ENABLE=true
 export GAIAD_P2P_MAX_NUM_OUTBOUND_PEERS=200
-export GAIAD_STATESYNC_RPC_SERVERS="https://rpc.cosmos.network:443,https://rpc.cosmos.network:443"
+export GAIAD_STATESYNC_RPC_SERVERS="https://cached-rpc-cosmos.sg1.online:443,https://cached-rpc-cosmos.sg1.online:443"
 export GAIAD_STATESYNC_TRUST_HEIGHT=$BLOCK_HEIGHT
 export GAIAD_STATESYNC_TRUST_HASH=$TRUST_HASH
 


### PR DESCRIPTION
This PR:

* adds iavl fast node to Gaia v9.1.x
* removes the depguard linter
* bumps golangci-lint

This pr is not necessarily intended to be merged, but is more to facilitate review by @jtremback 


