### PR TITLE
docs: Added docs for emergency upgrades

### DIFF
--- a/docs/validators/emergency-upgrades.md
+++ b/docs/validators/emergency-upgrades.md
@@ -1,0 +1,83 @@
+---
+order: 5
+title: Emergency Upgrades
+---
+
+## **Introduction**
+
+This article goes into the general flow of events for an emergency upgrade, pre-upgrade and during the upgrade for all validators.
+
+Emergency upgrades are an unfortunate necessity for all validators when running a PoS node.
+
+When a vunerability is discovered and responsibily disclosed, the vunerability will be reported to one of the channels described in the [Security.md](../../SECURITY.md).
+
+Once the vulnerability is patched and tested, the core team will reach out to all validators to update their nodes with the latest version.
+
+### **Cosmos Hub Upgrade Information**
+
+Depending on the severity of the vulnerability, the core teams and validators can take different actions.
+
+The core teams will try reach out **48 hours** or more before a scheduled upgrade, so that validators have time to inspect the changes and also adjust their internal planning accordingly.
+
+If the change is **non** state-breaking then the patch can be applied in a un-cordinated manner by validators asap.
+
+If the change is **state-breaking**, that will mean that the upgrade has to be co-ordinated for all validators at a certain block or halt-height.
+
+#### **Co-ordinated Upgrades**
+
+A co-ordinated upgrade will require updating your node configuration to the correct halt-height. The code teams will communicate the correct height for all validators via Email and [Discord](https://discord.com/channels/669268347736686612/798937713474142229).
+
+At the halt-height, you will swap out the old binaries for the new ones, while monitoring your node. Be sure to check-in on the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229), as notifications will be made pre/during/post upgrade on **this** channel.
+
+If you do have issues with the upgrade, please bring them up in the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) where the core teams will be monitoring progress and will help you resolve any issues that arise.
+
+Once the threshold of 67% voting power is reached by the upgraded validators, the Cosmos Hub network will start producing blocks. Note that this process might take between 5-20 mins depending on the required migrations for the upgrade and voting power present. Please be patient and check the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) for any updates.
+
+If there are any serious issues with the upgrade then you will notified on Discord to rollback the changes.
+
+#### **Rolling back an upgrade**
+
+During the network upgrade, core Cosmos teams will be monitoring the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229)  channel and communicating with validators on the status of the upgrade.
+
+During this time, the core teams will listen to validator needs to determine if the upgrade is experiencing unintended challenges. In the event of unexpected challenges, the core teams, after conferring with validators, may choose to declare that the upgrade will be skipped.
+
+**Note**: There is no particular need to restore a state snapshot prior to the upgrade height, unless specifically directed by core teams.
+
+### **Vulnerability Levels**
+
+This sections discusses the actions to be taken for different vulnerability levels.
+
+#### **Critical level vulnerabilities**
+
+For critical level vulnerabilities, the core teams will usually start a private patching effort with a number of key validators. By the time an emergency patch is released, the expectation is that a good proportion of the validator set have already upgraded. Vulnerabilities at this level should be updated immediately. We might ask validators to shut down the network until a patch is released, due to the potential consquences arising from the identified vulnerability.
+
+#### **High level vulnerabilities**
+
+For high level vulnerabilities, the core teams will reach out to validators to upgrade the chain asap.
+
+#### **Medium level vulnerabilities**
+
+For medium level vulnerabilities, the team will release a patch and may consider an out-of-band (emergency) release. We encourage validators to upgrade asap.
+
+#### **Low level vulnerabilities**
+
+Fixes for low level vulnerabilities are periodically rolled into point releases or if state breaking they are rolled into the next minor or major release.
+
+## **What to expect before the upgrade?**
+
+Once a patch is ready, the core teams will reach out to all the validators via a number of pre-established public or private channels depending on the severity of the vulnerability.
+
+Validators **MUST HAVE** their contact details on file by registering their teams on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) and joining the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel. This is necessary so that validators don't miss important updates and get jailed for missing blocks or have other operational issues.
+
+The core teams are happy to have a private Telegram channel with each validator team. Please reach out to the Discord admins to help set this up.
+
+## **Main Contact Points**
+
+The primary contact points for the Cosmos Hub are the core team at Informal Systems and the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel.
+
+## **Community**
+
+Discuss the finer details of being a validator on our community Discord and sign up for the Cosmos newsletter to get regular updates:
+
+* [Cosmos Developers Discord](https://discord.gg/cosmosnetwork)
+* [Newsletter](https://cosmos.network/updates/signup/)

--- a/docs/validators/emergency-upgrades.md
+++ b/docs/validators/emergency-upgrades.md
@@ -7,53 +7,58 @@ title: Emergency Upgrades
 
 This article goes into the general flow of events for an emergency upgrade, pre-upgrade and during the upgrade for all validators.
 
-Emergency upgrades are an unfortunate necessity for all validators when running a PoS node.
+Emergency upgrades are an unfortunate necessity for all validators when running a Proof-of-Stake node. When a vunerability is discovered and responsibily disclosed, the vunerability will be reported to one of the channels mentioned in the [Security.md](../../SECURITY.md).
 
-When a vunerability is discovered and responsibily disclosed, the vunerability will be reported to one of the channels described in the [Security.md](../../SECURITY.md).
+The process for updates has the following steps:
 
-Once the vulnerability is patched and tested, the core team will reach out to all validators to update their nodes with the latest version.
+- **Heads-up** - An annoucement from the relevant teams is made to validators, on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel, that a priority fix is incoming. As a result, validators should reserve resources to handle the changes in the next 1-3 of days. The messaging could also establish an official private communications channel for co-ordination.
+- **Release** - An official release will be made on GitHub on the Cosmos org. This should confirm the authenticity of the fix for validators. This will be an actual release of the source code that validators can inspect.
+- **Deployment** - Validator coordination and one-to-one communications to help them push through the changes.
+- **Advisory** - An advisory is released when all the impacted parties are upgraded and generally comes from the relevant teams responsible for the release **OR** the team responsible for patching the source code.
+
 
 ### **Cosmos Hub Upgrade Information**
 
-Depending on the severity of the vulnerability, the core teams and validators can take different actions.
+Depending on the severity of the vulnerability, the relevant teams and validators can take different actions.
 
-The core teams will try reach out **48 hours** or more before a scheduled upgrade, so that validators have time to inspect the changes and also adjust their internal planning accordingly.
+The relevant teams will try to reach out to validators as soon as possible, so that internal planning can be adjusted accordingly.
+Validators will have time to inspect the changes circa **24 hours** or more before a planned upgrade.
 
-If the change is **non** state-breaking then the patch can be applied in a un-cordinated manner by validators asap.
+If the change is **does not** require co-ordination, then the patch can be applied by validators **asap**.
 
-If the change is **state-breaking**, that will mean that the upgrade has to be co-ordinated for all validators at a certain block or halt-height.
+If the change requires co-ordination, then all validators will need to set a block or halt-height as highlighted in the communications.
 
 #### **Co-ordinated Upgrades**
 
-A co-ordinated upgrade will require updating your node configuration to the correct halt-height. The code teams will communicate the correct height for all validators via Email and [Discord](https://discord.com/channels/669268347736686612/798937713474142229).
+A co-ordinated upgrade will require updating your node configuration to the correct halt-height. The relevant teams will communicate the correct height for all validators via Email and [Discord](https://discord.com/channels/669268347736686612/798937713474142229).
 
-At the halt-height, you will swap out the old binaries for the new ones, while monitoring your node. Be sure to check-in on the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229), as notifications will be made pre/during/post upgrade on **this** channel.
+At the halt-height, you will swap out the old binaries for the new ones, while monitoring your node. Be sure to check-in on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork), as notifications will be made pre/during/post upgrade on **this** channel.
 
 If you do have issues with the upgrade, please bring them up in the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) where the core teams will be monitoring progress and will help you resolve any issues that arise.
 
-Once the threshold of 67% voting power is reached by the upgraded validators, the Cosmos Hub network will start producing blocks. Note that this process might take between 5-20 mins depending on the required migrations for the upgrade and voting power present. Please be patient and check the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) for any updates.
+Once the threshold of 67% voting power of upgraded validators is reached, the Cosmos Hub network will start producing blocks. Note that this process might take between 5-20 mins depending on the required migrations for the upgrade and voting power present. Please be patient and check the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) for any updates.
 
 If there are any serious issues with the upgrade then you will notified on Discord to rollback the changes.
 
 #### **Rolling back an upgrade**
 
-During the network upgrade, core Cosmos teams will be monitoring the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229)  channel and communicating with validators on the status of the upgrade.
+During the network upgrade, the relevant Cosmos teams will be monitoring the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229)  channel and communicating with validators on the status of the upgrade.
 
-During this time, the core teams will listen to validator needs to determine if the upgrade is experiencing unintended challenges. In the event of unexpected challenges, the core teams, after conferring with validators, may choose to declare that the upgrade will be skipped.
+During this time, the relevant teams will listen to validator needs to determine if the upgrade is experiencing unintended challenges. In the event of unexpected challenges, the relevant teams, after conferring with validators, may choose to declare that the upgrade will be skipped.
 
-**Note**: There is no particular need to restore a state snapshot prior to the upgrade height, unless specifically directed by core teams.
+**Note**: There is no particular need to restore a state snapshot prior to the upgrade height, unless specifically directed by relevant teams.
 
 ### **Vulnerability Levels**
 
-This sections discusses the actions to be taken for different vulnerability levels.
+This section discusses the actions to be taken for different vulnerability levels.
 
 #### **Critical level vulnerabilities**
 
-For critical level vulnerabilities, the core teams will usually start a private patching effort with a number of key validators. By the time an emergency patch is released, the expectation is that a good proportion of the validator set have already upgraded. Vulnerabilities at this level should be updated immediately. We might ask validators to shut down the network until a patch is released, due to the potential consquences arising from the identified vulnerability.
+For critical level vulnerabilities, the relevant teams will usually start a private patching effort with a number of key validators. By the time an emergency patch is released, the expectation is that a good proportion of the validator set have already upgraded. Vulnerabilities at this level should be updated immediately. We might ask validators to shut down the network until a patch is released, due to the potential consquences arising from the identified vulnerability.
 
 #### **High level vulnerabilities**
 
-For high level vulnerabilities, the core teams will reach out to validators to upgrade the chain asap.
+For high level vulnerabilities, the relevant teams will reach out to validators to upgrade the chain asap.
 
 #### **Medium level vulnerabilities**
 
@@ -61,19 +66,17 @@ For medium level vulnerabilities, the team will release a patch and may consider
 
 #### **Low level vulnerabilities**
 
-Fixes for low level vulnerabilities are periodically rolled into point releases or if state breaking they are rolled into the next minor or major release.
+Fixes for low level vulnerabilities are periodically rolled into point releases or if state breaking, they are rolled into the next minor or major release.
 
 ## **What to expect before the upgrade?**
 
-Once a patch is ready, the core teams will reach out to all the validators via a number of pre-established public or private channels depending on the severity of the vulnerability.
+Once a patch is ready, the relevant teams will reach out to all the validators via a number of pre-established public or private channels depending on the severity of the vulnerability.
 
-Validators **MUST HAVE** their contact details on file by registering their teams on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) and joining the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel. This is necessary so that validators don't miss important updates and get jailed for missing blocks or have other operational issues.
-
-The core teams are happy to have a private Telegram channel with each validator team. Please reach out to the Discord admins to help set this up.
+Validators **MUST HAVE** their contact details on file by registering their teams on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) and join the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel. This is necessary so that validators don't miss important updates and get jailed for missing blocks or have other operational issues.
 
 ## **Main Contact Points**
 
-The primary contact points for the Cosmos Hub are the core team at Informal Systems and the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel.
+The primary contact points for the Cosmos Hub are the relevant teams at Informal Systems and the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel.
 
 ## **Community**
 

--- a/docs/validators/emergency-upgrades.md
+++ b/docs/validators/emergency-upgrades.md
@@ -24,7 +24,7 @@ Depending on the severity of the vulnerability, the relevant teams and validator
 The relevant teams will try to reach out to validators as soon as possible, so that internal planning can be adjusted accordingly.
 Validators will have time to inspect the changes circa **24 hours** or more before a planned upgrade.
 
-If the change is **does not** require co-ordination, then the patch can be applied by validators **asap**.
+If the change **does not** require co-ordination, then the patch can be applied by validators **asap**.
 
 If the change requires co-ordination, then all validators will need to set a block or halt-height as highlighted in the communications.
 
@@ -34,7 +34,7 @@ A co-ordinated upgrade will require updating your node configuration to the corr
 
 At the halt-height, you will swap out the old binaries for the new ones, while monitoring your node. Be sure to check-in on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork), as notifications will be made pre/during/post upgrade on **this** channel.
 
-If you do have issues with the upgrade, please bring them up in the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) where the core teams will be monitoring progress and will help you resolve any issues that arise.
+If you do have issues with the upgrade, please bring them up in the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) where the relevant teams will be monitoring progress and will help you resolve any issues that arise.
 
 Once the threshold of 67% voting power of upgraded validators is reached, the Cosmos Hub network will start producing blocks. Note that this process might take between 5-20 mins depending on the required migrations for the upgrade and voting power present. Please be patient and check the [Discord channel](https://discord.com/channels/669268347736686612/798937713474142229) for any updates.
 
@@ -72,15 +72,15 @@ Fixes for low level vulnerabilities are periodically rolled into point releases 
 
 Once a patch is ready, the relevant teams will reach out to all the validators via a number of pre-established public or private channels depending on the severity of the vulnerability.
 
-Validators **MUST HAVE** their contact details on file by registering their teams on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) and join the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel. This is necessary so that validators don't miss important updates and get jailed for missing blocks or have other operational issues.
+Validators **MUST HAVE** their contact details on file by registering their teams on [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) and join the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel. This is necessary so that validators don't miss important updates and get jailed for missing blocks or have other operational issues without the required support.
 
 ## **Main Contact Points**
 
-The primary contact points for the Cosmos Hub are the relevant teams at Informal Systems and the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel.
+The primary contact points for the Cosmos Hub are the relevant teams at Informal Systems and the Interchain Foundation, on the [Cosmos Developers Discord](https://discord.gg/cosmosnetwork) on the [cosmos-hub-validators-verified](https://discord.com/channels/669268347736686612/798937713474142229) channel.
 
 ## **Community**
 
-Discuss the finer details of being a validator on our community Discord and sign up for the Cosmos newsletter to get regular updates:
+Discuss the finer details of being a validator on the community Discord and sign up for the Cosmos newsletter to get regular updates:
 
 * [Cosmos Developers Discord](https://discord.gg/cosmosnetwork)
 * [Newsletter](https://cosmos.network/updates/signup/)


### PR DESCRIPTION
## Description

Closes: #2557

Adds a generic emergency doc, so that all validators understand the process involved with emergency upgrades.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

