### PR TITLE
ci: update goreleaser tag sort options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: git fetch --force --tags
 
       - uses: actions/setup-go@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,6 @@ git:
   # What should be used to sort tags when gathering the current and previous
   # tags if there are more than one tag in the same commit.
   #
-  ##  source: https://goreleaser.com/customization/git/
+  # source: https://goreleaser.com/customization/git/
   tag_sort: -version:refname
   prerelease_suffix: "-rc"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,8 +59,6 @@ git:
   # What should be used to sort tags when gathering the current and previous
   # tags if there are more than one tag in the same commit.
   #
-  # Default: '-version:refname'
   ##  source: https://goreleaser.com/customization/git/
-  ## "tag_sort: -version:creatordate" from the docs is a typo, it should be "tag_sort: -creatordate"
-  tag_sort: -creatordate
+  tag_sort: -version:refname
   prerelease_suffix: "-rc"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,5 +60,6 @@ git:
   # tags if there are more than one tag in the same commit.
   #
   # Default: '-version:refname'
-  # source: https://goreleaser.com/customization/git/
-  tag_sort: -version:creatordate
+  ##  source: https://goreleaser.com/customization/git/
+  ## "tag_sort: -version:creatordate" from the docs is a typo, it should be "tag_sort: -creatordate"
+  tag_sort: -creatordate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,3 +63,4 @@ git:
   ##  source: https://goreleaser.com/customization/git/
   ## "tag_sort: -version:creatordate" from the docs is a typo, it should be "tag_sort: -creatordate"
   tag_sort: -creatordate
+  prerelease_suffix: "-rc"


### PR DESCRIPTION
## Description

Closes: #2709

[goreleaser docs](https://goreleaser.com/customization/git/) advise using `tag_sort: -version:creatordate`.

However, `-version:creatordate` behaves unexpectedly since the correct sort option is just `-creatordate`.

After testing using `-creatordate` it was discovered that the option will sometimes ignore release newer release candidates so `-version:refname` was chosen instead. Additinally, `prerelease_suffix: "-rc"` was added to filter release candidates more accurately.


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

