### PR TITLE
docs: remove update warning

### DIFF
--- a/docs/hub-overview/overview.md
+++ b/docs/hub-overview/overview.md
@@ -3,13 +3,6 @@ order: 1
 title: Introduction
 ---
 
-::: warning
-### **v11 Upgrade**
-Cosmos Hub will be upgraded to [v11](https://github.com/cosmos/gaia/releases/tag/v11.0.0) at block height: **16,596,000**
-
-To upgrade from v10 check the [**upgrade guide**](../migration/cosmoshub-4-v11-upgrade.md)
-:::
-
 ![Welcome to the Cosmos Hub](../images/cosmos-hub-image.jpg)
 
 # Introduction


### PR DESCRIPTION
## Description

Cosmos Hub is already at block [16904634](https://www.mintscan.io/cosmos/blocks/16904634) which exceeds the height mentioned in this upgrade warning.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

