### PR TITLE
docs: schedule testnet upgrade to v13

### DIFF
--- a/docs/hub-tutorials/join-testnet.md
+++ b/docs/hub-tutorials/join-testnet.md
@@ -22,7 +22,7 @@ The table below shows all past and upcoming versions of the public testnet.
 
 |   Release   | Upgrade Block Height |    Upgrade Date     |
 | :---------: | :------------------: | :-----------------: |
-| v13.0.0-rc0 |         TBA          |         TBA         |
+| v13.0.0-rc0 |      17,996,550      |     2023-09-20      |
 | v12.0.0-rc0 |      17,550,150      |     2023-08-23      |
 | v11.0.0-rc0 |      17,107,825      |     2023-07-26      |
 | v10.0.0-rc0 |      16,117,530      |     2023-05-24      |


### PR DESCRIPTION
## Description

Closes: #2742

* Sets the Gaia v13 upgrade height and date for the release testnet, `theta-testnet-001`.

This is the page that is being updated: https://hub.cosmos.network/main/hub-tutorials/join-testnet.html

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct `docs:` prefix in the PR title
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

