### PR TITLE
docs: fix "follwing" typo

### DIFF
--- a/docs/resources/genesis.md
+++ b/docs/resources/genesis.md
@@ -172,7 +172,7 @@ Let us break down the parameters:
 
 ### Mint
 
-The `mint` module governs the logic of inflating the supply of token. The `mint` section in the genesis file looks like the follwing:
+The `mint` module governs the logic of inflating the supply of token. The `mint` section in the genesis file looks like the following:
 
 ```json
 "mint": {
@@ -206,7 +206,7 @@ Let us break down the parameters:
 
 ### Distribution
 
-The `distribution` module handles the logic of distribution block provisions and fees to validators and delegators. The `distribution` section in the genesis file looks like the follwing:
+The `distribution` module handles the logic of distribution block provisions and fees to validators and delegators. The `distribution` section in the genesis file looks like the following:
 
 ```json
     "distribution": {


### PR DESCRIPTION
## Description

In genesis.md "following" is written "follwing" in two places.
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

