### PR TITLE
docs: Clarify genesis has timestamps for vesting

### DIFF
--- a/docs/resources/genesis.md
+++ b/docs/resources/genesis.md
@@ -113,8 +113,8 @@ Let us break down the parameters:
 - `original_vesting`: Vesting is natively supported by `gaia`. You can define an amount of token owned by the account that needs to be vested for a period of time before they can be transferred. Vested tokens can be delegated. Default value is `null`.
 - `delegated_free`: Amount of delegated tokens that can be transferred after they've been vested. Most of the time, will be `null` in genesis.
 - `delegated_vesting`: Amount of delegated tokens that are still vesting. Most of the time, will be `null` in genesis.
-- `start_time`: Block at which the vesting period starts. `0` most of the time in genesis.
-- `end_time`: Block at which the vesting period ends. `0` if no vesting for this account.
+- `start_time`: Timestamp at which the vesting period starts. `0` most of the time in genesis.
+- `end_time`: Timestamp at which the vesting period ends. `0` if no vesting for this account.
 
 ### Bank
 


### PR DESCRIPTION
## Description

Closes: #2872

Previously, the documentation mentioned that start_time and end_time refer to blocks. This could be interpreted as saying start_time and end_time are block heights. However, `x/auth/vesting` documentation at https://docs.cosmos.network/v0.50/build/modules/auth/vesting clarifies these are block times.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)