### PR TITLE
fix!: add missing consensus module registration; register gov hooks

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -331,7 +331,9 @@ func NewAppKeeper(
 	appKeepers.GovKeeper.SetLegacyRouter(govRouter)
 
 	appKeepers.GovKeeper = appKeepers.GovKeeper.SetHooks(
-		appKeepers.ProviderKeeper.Hooks(),
+		govtypes.NewMultiGovHooks(
+			appKeepers.ProviderKeeper.Hooks(),
+		),
 	)
 
 	evidenceKeeper := evidencekeeper.NewKeeper(

--- a/app/modules.go
+++ b/app/modules.go
@@ -144,6 +144,7 @@ func appModules(
 		ibc.NewAppModule(app.IBCKeeper),
 		sdkparams.NewAppModule(app.ParamsKeeper),
 		globalfee.NewAppModule(app.GetSubspace(globalfee.ModuleName)),
+		consensus.NewAppModule(appCodec, app.ConsensusParamsKeeper),
 		app.TransferModule,
 		app.ICAModule,
 		app.PFMRouterModule,

--- a/app/upgrades/v15/upgrades.go
+++ b/app/upgrades/v15/upgrades.go
@@ -3,6 +3,7 @@ package v15
 import (
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,6 +17,7 @@ import (
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
@@ -40,6 +42,9 @@ func CreateUpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting module migrations...")
+		baseAppLegacySS := keepers.ParamsKeeper.Subspace(baseapp.Paramspace).
+			WithKeyTable(paramstypes.ConsensusParamsKeyTable())
+		baseapp.MigrateParams(ctx, baseAppLegacySS, &keepers.ConsensusParamsKeeper)
 
 		vm, err := mm.RunMigrations(ctx, configurator, vm)
 		if err != nil {


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, deps, or refactor.
-->

A bug manifested during v15 where the relayers were not able to relay messages between gaia and any other chain. The bug was found while testing consumer chain interactions but it could have affected all IBC interactions.

## Description

`consensus.NewAppModule()` was not called and the `consensus` module was not added to the module manager.

This resulted in the `/block_results` queries returning empty `consensus_param_updates` field. While querying block events, relayers would fail to parse the block (due to missing required fields).

`gaiad@v14.x`
```json
{
    "jsonrpc": "2.0",
    "id": -1,
    "result": {
        "height": "3",
        "txs_results": null,
        "begin_block_events": [
           "<ommited for brevity>"
        ],
        "end_block_events": null,
        "validator_updates": null,
        "consensus_param_updates": {
            "block": {
                "max_bytes": "22020096",
                "max_gas": "-1"
            },
            "evidence": {
                "max_age_num_blocks": "100000",
                "max_age_duration": "172800000000000",
                "max_bytes": "1048576"
            },
            "validator": {
                "pub_key_types": [
                    "ed25519"
                ]
            }
        }
    }
}
```

`gaiad@v15.x` before the fix:
```json
{
    "jsonrpc": "2.0",
    "id": -1,
    "result": {
        "height": "3",
        "txs_results": null,
        "begin_block_events": [
            "<ommited for brevity>"
         ],
        "end_block_events": null,
        "validator_updates": null,
        "consensus_param_updates": {}
    }
}
```

Changelog entry probably not needed since this never reached production.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if API, client, or state breaking change (i.e., requires minor or major version bump)
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [x] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry in `.changelog` (for details, see [contributing guidelines](../../CONTRIBUTING.md#changelog))
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
