### PR TITLE
docs: release testnet upgraded to v15

### DIFF
--- a/docs/docs/hub-tutorials/join-testnet.md
+++ b/docs/docs/hub-tutorials/join-testnet.md
@@ -5,7 +5,7 @@ order: 3
 
 This tutorial will provide all necessary instructions for joining the current public testnet. If you're interested in more advanced configuration and synchronization options, see [Join Mainnet](./join-mainnet.md) for a detailed walkthrough.
 
-* Current Version: v14
+* Current Version: v15
 * Chain ID: `theta-testnet-001`
 
 ## Background
@@ -20,10 +20,13 @@ The table below shows all past and upcoming versions of the public testnet.
 
 |   Release   | Upgrade Block Height |    Upgrade Date     |
 | :---------: | :------------------: | :-----------------: |
-| v15.0.0-rc0 |         TBA          |         TBA         |
-| v14.0.0-rc0 |         TBA          |         TBA         |
-| v13.0.0-rc0 |         TBA          |         TBA         |
-| v12.0.0-rc0 |         TBA          |         TBA         |
+| v16.0.0-rc0 |         TBA          |         TBA         |
+| v15.0.0-rc0 |      20,269,900      |     2024-02-13      |
+| v14.1.0-rc0 |      18,986,400      |     2023-11-22      |
+| v14.0.0-rc1 |      18,876,500      |     2023-11-15      |
+| v14.0.0-rc0 |      18,766,800      |     2023-11-08      |
+| v13.0.0-rc0 |      17,996,550      |     2023-09-20      |
+| v12.0.0-rc0 |      17,550,150      |     2023-08-23      |
 | v11.0.0-rc0 |      17,107,825      |     2023-07-26      |
 | v10.0.0-rc0 |      16,117,530      |     2023-05-24      |
 | v9.0.0-rc3  |      14,476,206      |     2023-02-08      |
@@ -87,7 +90,7 @@ cd $HOME
 git clone https://github.com/cosmos/gaia
 cd gaia
 # To sync from genesis, comment out the next line.
-git checkout v13.0.0
+git checkout v15.0.0-rc0
 # To sync from genesis, uncomment the next line and skip the State Sync Setup section.
 # git checkout v6.0.4
 make install
@@ -105,7 +108,7 @@ mv genesis.json $HOME/.gaia/config/genesis.json
 
 # Set minimum gas price & peers
 cd $HOME/.gaia/config
-sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uatom"/' app.toml
+sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.005uatom"/' app.toml
 sed -i 's/seeds = ""/seeds = "639d50339d7045436c756a042906b9a69970913f@seed-01.theta-testnet.polypore.xyz:26656,3e506472683ceb7ed75c1578d092c79785c27857@seed-02.theta-testnet.polypore.xyz:26656"/' config.toml
 ```
 
@@ -245,7 +248,7 @@ There are three ways you can update the binary:
 
 The instructions below are for option 2. For more information on auto-download with Cosmovisor, see the relevant [documentation](https://github.com/cosmos/cosmos-sdk/tree/main/tools/cosmovisor#auto-download) in the Cosmos SDK repo.
 
-If the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES` is set to `false`, Cosmovisor will look for the new binary in a folder that matches the name of the upgrade specified in the software upgrade proposal. For the `v13` upgrade, the expected folder structure would look as follows:
+If the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES` is set to `false`, Cosmovisor will look for the new binary in a folder that matches the name of the upgrade specified in the software upgrade proposal. For the `v16` upgrade, the expected folder structure would look as follows:
 
 ```shell
 .gaia
@@ -255,7 +258,7 @@ If the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES` is set to `false`, 
     │   └── bin
     |       └── gaiad
     └── upgrades
-        └── v13
+        └── v16
             └── bin
                 └── gaiad
 ```
@@ -263,7 +266,7 @@ If the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES` is set to `false`, 
 Prepare the upgrade directory
 
 ```shell
-mkdir -p ~/.gaia/cosmovisor/upgrades/v14/bin
+mkdir -p ~/.gaia/cosmovisor/upgrades/v16/bin
 ```
 
 Download and install the new binary version.
@@ -271,11 +274,11 @@ Download and install the new binary version.
 ```shell
 cd $HOME/gaia
 git pull
-git checkout v13.0.0-rc0
+git checkout v16.0.0-rc0
 make install
 
-# Copy the new binary to the v13 upgrade directory
-cp ~/go/bin/gaiad ~/.gaia/cosmovisor/upgrades/v13/bin/gaiad
+# Copy the new binary to the v16 upgrade directory
+cp ~/go/bin/gaiad ~/.gaia/cosmovisor/upgrades/v16/bin/gaiad
 ```
 
 When the upgrade height is reached, Cosmovisor will stop the gaiad binary, copy the new binary to the `current/bin` folder and restart. After a few minutes, the node should start syncing blocks using the new binary.

--- a/docs/docs/hub-tutorials/join-testnet.md
+++ b/docs/docs/hub-tutorials/join-testnet.md
@@ -72,14 +72,14 @@ Install build tools and Go.
 ```shell
 sudo apt-get update
 sudo apt-get install -y make gcc
-wget https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.21.6.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.21.6.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 
 ### Installation & Configuration
 
-You will need to install and configure the Gaia binary using the script below. The Cosmos Hub Public Testnet is running Gaia [`v13.0.0`](https://github.com/cosmos/gaia/releases/tag/v13.0.0).
+You will need to install and configure the Gaia binary using the script below. The Cosmos Hub Public Testnet is running Gaia [`v15.0.0-rc0`](https://github.com/cosmos/gaia/releases/tag/v15.0.0-rc0).
 
 * For up-to-date endpoints like seeds and state sync RPC servers, visit the [testnets repository](https://github.com/cosmos/testnets/tree/master/public).
 
@@ -225,7 +225,7 @@ systemctl start cosmovisor.service
 To follow the service log, run `journalctl -fu gaiad` or `journalctl -fu cosmovisor`.
 
 * If you are using State Sync, the chain will start syncing once a snapshot is found and verified. Syncing to the current block height should take less than half an hour.
-* If you are using Fast Sync, the chain will start syncing once the first block after genesis is found among the peers. **Syncing to the current block height will take several days**.
+* If you are using Block Sync, the chain will start syncing once the first block after genesis is found among the peers. **Syncing to the current block height will take several days**.
 
 ## Create a Validator (Optional)
 


### PR DESCRIPTION
## Description

Closes: #2940 

This PR updates the current version for the release testnet, `theta-testnet-001`, to Gaia v15.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct `docs:` prefix in the PR title
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

