### PR TITLE
fix!: assure historic TxExtensionOptions encoding validity

### DIFF
--- a/x/metaprotocols/types/codec.go
+++ b/x/metaprotocols/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	tx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
 // RegisterInterfaces adds the x/metaprotocols module's interfaces to the provided InterfaceRegistry
@@ -11,5 +12,8 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*tx.TxExtensionOptionI)(nil),
 		&ExtensionData{},
+		// needs to be registered to allow parsing of historic data stored in TxExtensionOptions
+		// the app does not interact with this message in any way but it performs an unmarshal which must not fail
+		&authz.MsgRevoke{},
 	)
 }


### PR DESCRIPTION
Changes ensure messages submitted in TxExtensionOptions remain compatible with cosmos-sdk v0.45.x-ics.