### PR TITLE
tests: LastValidatorPower set to voting power value

### DIFF
--- a/cmd/gaiad/cmd/README.md
+++ b/cmd/gaiad/cmd/README.md
@@ -11,7 +11,7 @@ The command is added as a sub-command of the `gaiad testnet` command.
 The gaia binary will cointain the testnet extensions only if the `unsafe_start_local_validator` build tags is used.
 
 ```shell
-make build BUILD_TAGS="-tag unsafe_start_local_validator
+make build BUILD_TAGS="-tag unsafe_start_local_validator"
 ```
 
 ## CLI usage

--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -37,6 +37,10 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
+const (
+	valVotingPower int64 = 900000000000000
+)
+
 var (
 	flagValidatorOperatorAddress = "validator-operator"
 	flagValidatorPubKey          = "validator-pubkey"
@@ -186,7 +190,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 		ConsensusPubkey: pubkeyAny,
 		Jailed:          false,
 		Status:          stakingtypes.Bonded,
-		Tokens:          sdk.NewInt(900000000000000),
+		Tokens:          sdk.NewInt(valVotingPower),
 		DelegatorShares: sdk.MustNewDecFromStr("10000000"),
 		Description: stakingtypes.Description{
 			Moniker: "Testnet Validator",
@@ -225,7 +229,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 		return err
 	}
 	app.StakingKeeper.SetValidatorByPowerIndex(appCtx, newVal)
-	app.StakingKeeper.SetLastValidatorPower(appCtx, newVal.GetOperator(), 900000000000000)
+	app.StakingKeeper.SetLastValidatorPower(appCtx, newVal.GetOperator(), valVotingPower)
 	if err := app.StakingKeeper.Hooks().AfterValidatorCreated(appCtx, newVal.GetOperator()); err != nil {
 		return err
 	}
@@ -274,7 +278,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 
 func updateConsensusState(logger log.Logger, appOpts servertypes.AppOptions, appHeight int64, args valArgs) error {
 	// create validator set from the local validator
-	newTmVal := tmtypes.NewValidator(tmd25519.PubKey(args.validatorConsPubKeyByte), 900000000000000)
+	newTmVal := tmtypes.NewValidator(tmd25519.PubKey(args.validatorConsPubKeyByte), valVotingPower)
 	vals := []*tmtypes.Validator{newTmVal}
 	validatorSet := tmtypes.NewValidatorSet(vals)
 

--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -225,7 +225,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 		return err
 	}
 	app.StakingKeeper.SetValidatorByPowerIndex(appCtx, newVal)
-	app.StakingKeeper.SetLastValidatorPower(appCtx, newVal.GetOperator(), 0)
+	app.StakingKeeper.SetLastValidatorPower(appCtx, newVal.GetOperator(), 900000000000000)
 	if err := app.StakingKeeper.Hooks().AfterValidatorCreated(appCtx, newVal.GetOperator()); err != nil {
 		return err
 	}


### PR DESCRIPTION
When changing app state for local testing LastValidatorPower should be set to voting power. Previously it was set to 0 and this PR fixes that.