### PR TITLE
deps: update feemarket initial params

### DIFF
--- a/app/upgrades/v18/upgrades.go
+++ b/app/upgrades/v18/upgrades.go
@@ -11,6 +11,7 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
 	"github.com/cosmos/gaia/v18/app/keepers"
 	"github.com/cosmos/gaia/v18/types"
@@ -66,9 +67,9 @@ func ConfigureFeeMarketModule(ctx sdk.Context, keepers *keepers.AppKeepers) erro
 
 	params.Enabled = true
 	params.FeeDenom = types.UAtomDenom
-	params.DistributeFees = true
+	params.DistributeFees = false // burn fees
 	params.MinBaseGasPrice = sdk.MustNewDecFromStr("0.005")
-	params.MaxBlockUtilization = 100000000
+	params.MaxBlockUtilization = feemarkettypes.DefaultMaxBlockUtilization
 	if err := keepers.FeeMarketKeeper.SetParams(ctx, params); err != nil {
 		return err
 	}

--- a/app/upgrades/v18/upgrades.go
+++ b/app/upgrades/v18/upgrades.go
@@ -3,6 +3,8 @@ package v18
 import (
 	"time"
 
+	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
+
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,7 +13,6 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
 	"github.com/cosmos/gaia/v18/app/keepers"
 	"github.com/cosmos/gaia/v18/types"


### PR DESCRIPTION
Update initial feemarket params to match EIP-1559:
* send fees to burn address instead of distributing to fee collector
* set `MaxBlockUtilization` to `30 000 000` gas units.