### PR TITLE
build: use dedicated CI runner for tests and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -9,7 +9,7 @@ on:
       
 jobs:
   cleanup-runs:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
@@ -17,7 +17,7 @@ jobs:
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -30,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-go-runsim-binary
 
   test-sim-nondeterminism:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     needs: newbuild
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
   test-sim-multi-seed-short:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
   newbuild:
-      runs-on: ubuntu-latest
+      runs-on: Gaia-Runner-medium
       steps:
         - uses: actions/setup-go@v5
           with:
@@ -91,7 +91,7 @@ jobs:
             key: ${{ runner.os }}-go-runsim-binary
 
   install-runsim:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     needs: build
     steps:
       - name: install runsim
@@ -102,7 +102,7 @@ jobs:
           key: ${{ runner.os }}-go-runsim-binary
 
   test-sim-multi-seed-long:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     needs: [build, install-runsim]
     steps:
       - uses: actions/setup-go@v5
@@ -116,3 +116,5 @@ jobs:
       - name: test-sim-multi-seed-long
         run: |
           make test-sim-multi-seed-long
+        if: "env.GIT_DIFF != ''"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           path: ./profile.out
 
   test-e2e:
-    runs-on: large-sdk-runner
+    runs-on: Gaia-Runner-medium
     timeout-minutes: 45
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: Gaia-Runner-medium
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -54,7 +54,7 @@ jobs:
           path: ./profile.out
 
   test-e2e:
-    runs-on: ubuntu-latest
+    runs-on: gaia-runner-medium
     timeout-minutes: 45
     steps:
       - uses: actions/setup-go@v5
@@ -108,7 +108,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   liveness-test:
-    runs-on: ubuntu-latest
+    runs-on: gaia-runner-medium
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           path: ./profile.out
 
   test-e2e:
-    runs-on: gaia-runner-medium
+    runs-on: large-sdk-runner
     timeout-minutes: 45
     steps:
       - uses: actions/setup-go@v5
@@ -108,7 +108,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   liveness-test:
-    runs-on: gaia-runner-medium
+    runs-on: Gaia-Runner-medium
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes: XXXXX

Set a dedicated runner for tests and release.

Changes can help avoid queues in the afternoons and alleviate some stress about releases.