### PR TITLE
fix: fix GIT_DIFF in the docker workflow.

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -23,18 +23,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            **/Makefile
-            Makefile
-            Dockerfile
+      - name: Get new commits for nightly build
+        run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
+        if: "${{ env.GITHUB_EVENT_NAME == 'schedule' }}"
+
+      - name: Set new commits for other builds
+        run: echo "NEW_COMMIT_COUNT=1" >> $GITHUB_ENV
+        if: "${{ env.GITHUB_EVENT_NAME != 'schedule' }}"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3.2.0
@@ -58,4 +53,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-        if: env.GIT_DIFF
+        if: ${{ env.NEW_COMMIT_COUNT > 0 }}


### PR DESCRIPTION
## Description

It turns out the get-diff-action only works on `push` and `pull_request` events, and will report an empty diff otherwise. This makes it so that we only run nightly builds if there's been a commit in the last 24h. Builds from workflow_dispatch and releases are always triggered.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if API, client, or state breaking change (i.e., requires minor or major version bump)
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry in `.changelog` (for details, see [contributing guidelines](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#changelog))
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed