### PR TITLE
chore: bump app version to v19

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.21"
+        go-version: "1.22"
         check-latest: true
    
    # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: run-vulncheck
         id: vulncheck

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v4.0.2
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |

--- a/.github/workflows/sim-label.yml
+++ b/.github/workflows/sim-label.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v4.0.2
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: actions/cache@v4.0.2
         with:
           path: ~/go/bin

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v4.0.2
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
@@ -82,7 +82,7 @@ jobs:
       steps:
         - uses: actions/setup-go@v5
           with:
-            go-version: 1.21.x
+            go-version: 1.22.x
         - name: Install runsim
           run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
         - uses: actions/cache@v4.0.2
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: actions/checkout@v4
       - uses: actions/cache@v4.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
       # the old gaiad binary version is hardcoded, need to be updated each major release.
       - name: Install Old Gaiad
         run: |
-          git checkout v17.0.0
+          git checkout v18.0.0
           make build
           cp ./build/gaiad ./build/gaiadold
           go clean -modcache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
         with:
@@ -159,7 +159,7 @@ jobs:
             Makefile
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       # the old gaiad binary version is hardcoded, need to be updated each major release.
       - name: Install Old Gaiad
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
       # the old gaiad binary version is hardcoded, need to be updated each major release.
       - name: Install Old Gaiad
         run: |
-          git checkout v18.0.0
+          git checkout v18.1.0
           make build
           cp ./build/gaiad ./build/gaiadold
           go clean -modcache

--- a/ante/ante.go
+++ b/ante/ante.go
@@ -18,7 +18,7 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	gaiaerrors "github.com/cosmos/gaia/v18/types/errors"
+	gaiaerrors "github.com/cosmos/gaia/v19/types/errors"
 )
 
 // UseFeeMarketDecorator to make the integration testing easier: we can switch off its ante and post decorators with this flag

--- a/ante/gov_expedited_ante.go
+++ b/ante/gov_expedited_ante.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
-	gaiaerrors "github.com/cosmos/gaia/v18/types/errors"
+	gaiaerrors "github.com/cosmos/gaia/v19/types/errors"
 )
 
 var expeditedPropDecoratorEnabled = true

--- a/ante/gov_expedited_ante_test.go
+++ b/ante/gov_expedited_ante_test.go
@@ -12,8 +12,8 @@ import (
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/ante"
-	"github.com/cosmos/gaia/v18/app/helpers"
+	"github.com/cosmos/gaia/v19/ante"
+	"github.com/cosmos/gaia/v19/app/helpers"
 )
 
 func TestGovExpeditedProposalsDecorator(t *testing.T) {

--- a/ante/gov_vote_ante.go
+++ b/ante/gov_vote_ante.go
@@ -11,7 +11,7 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	gaiaerrors "github.com/cosmos/gaia/v18/types/errors"
+	gaiaerrors "github.com/cosmos/gaia/v19/types/errors"
 )
 
 var (

--- a/ante/gov_vote_ante_test.go
+++ b/ante/gov_vote_ante_test.go
@@ -15,8 +15,8 @@ import (
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/cosmos/gaia/v18/ante"
-	"github.com/cosmos/gaia/v18/app/helpers"
+	"github.com/cosmos/gaia/v19/ante"
+	"github.com/cosmos/gaia/v19/app/helpers"
 )
 
 // Test that the GovVoteDecorator rejects v1beta1 vote messages from accounts with less than 1 atom staked

--- a/app/app.go
+++ b/app/app.go
@@ -57,11 +57,11 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	gaiaante "github.com/cosmos/gaia/v18/ante"
-	"github.com/cosmos/gaia/v18/app/keepers"
-	"github.com/cosmos/gaia/v18/app/params"
-	"github.com/cosmos/gaia/v18/app/upgrades"
-	v18 "github.com/cosmos/gaia/v18/app/upgrades/v18"
+	gaiaante "github.com/cosmos/gaia/v19/ante"
+	"github.com/cosmos/gaia/v19/app/keepers"
+	"github.com/cosmos/gaia/v19/app/params"
+	"github.com/cosmos/gaia/v19/app/upgrades"
+	v18 "github.com/cosmos/gaia/v19/app/upgrades/v18"
 )
 
 var (

--- a/app/app.go
+++ b/app/app.go
@@ -61,14 +61,14 @@ import (
 	"github.com/cosmos/gaia/v19/app/keepers"
 	"github.com/cosmos/gaia/v19/app/params"
 	"github.com/cosmos/gaia/v19/app/upgrades"
-	v18 "github.com/cosmos/gaia/v19/app/upgrades/v18"
+	v19 "github.com/cosmos/gaia/v19/app/upgrades/v19"
 )
 
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
 
-	Upgrades = []upgrades.Upgrade{v18.Upgrade}
+	Upgrades = []upgrades.Upgrade{v19.Upgrade}
 )
 
 var (

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -13,8 +13,8 @@ import (
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 
-	gaia "github.com/cosmos/gaia/v18/app"
-	gaiahelpers "github.com/cosmos/gaia/v18/app/helpers"
+	gaia "github.com/cosmos/gaia/v19/app"
+	gaiahelpers "github.com/cosmos/gaia/v19/app/helpers"
 )
 
 type EmptyAppOptions struct{}

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -3,7 +3,7 @@ package gaia
 import (
 	"github.com/cosmos/cosmos-sdk/std"
 
-	"github.com/cosmos/gaia/v18/app/params"
+	"github.com/cosmos/gaia/v19/app/params"
 )
 
 func RegisterEncodingConfig() params.EncodingConfig {

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -3,7 +3,7 @@ package gaia
 import (
 	"encoding/json"
 
-	"github.com/cosmos/gaia/v18/app/params"
+	"github.com/cosmos/gaia/v19/app/params"
 )
 
 // The genesis state of the blockchain is represented here as a map of raw json

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -26,7 +26,7 @@ import (
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 
-	gaiaapp "github.com/cosmos/gaia/v18/app"
+	gaiaapp "github.com/cosmos/gaia/v19/app"
 )
 
 // SimAppChainID hardcoded chainID for simulation

--- a/app/modules.go
+++ b/app/modules.go
@@ -65,9 +65,9 @@ import (
 	wasm "github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	gaiaappparams "github.com/cosmos/gaia/v18/app/params"
-	"github.com/cosmos/gaia/v18/x/metaprotocols"
-	metaprotocolstypes "github.com/cosmos/gaia/v18/x/metaprotocols/types"
+	gaiaappparams "github.com/cosmos/gaia/v19/app/params"
+	"github.com/cosmos/gaia/v19/x/metaprotocols"
+	metaprotocolstypes "github.com/cosmos/gaia/v19/x/metaprotocols/types"
 )
 
 var maccPerms = map[string][]string{

--- a/app/post.go
+++ b/app/post.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/cosmos/gaia/v18/ante"
+	"github.com/cosmos/gaia/v19/ante"
 )
 
 // PostHandlerOptions are the options required for constructing a FeeMarket PostHandler.

--- a/app/sim/sim_state.go
+++ b/app/sim/sim_state.go
@@ -22,8 +22,8 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	gaia "github.com/cosmos/gaia/v18/app"
-	"github.com/cosmos/gaia/v18/app/params"
+	gaia "github.com/cosmos/gaia/v19/app"
+	"github.com/cosmos/gaia/v19/app/params"
 )
 
 // Simulation parameter constants

--- a/app/sim/sim_utils.go
+++ b/app/sim/sim_utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	gaia "github.com/cosmos/gaia/v18/app"
+	gaia "github.com/cosmos/gaia/v19/app"
 )
 
 // SimulationOperations retrieves the simulation params from the provided file path

--- a/app/sim_bench_test.go
+++ b/app/sim_bench_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 
-	gaia "github.com/cosmos/gaia/v18/app"
-	"github.com/cosmos/gaia/v18/app/sim"
+	gaia "github.com/cosmos/gaia/v19/app"
+	"github.com/cosmos/gaia/v19/app/sim"
 )
 
 // Profile with:

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 
-	"github.com/cosmos/gaia/v18/ante"
-	gaia "github.com/cosmos/gaia/v18/app"
+	"github.com/cosmos/gaia/v19/ante"
+	gaia "github.com/cosmos/gaia/v19/app"
 	// "github.com/cosmos/gaia/v11/app/helpers"
 	// "github.com/cosmos/gaia/v11/app/params"
-	"github.com/cosmos/gaia/v18/app/sim"
+	"github.com/cosmos/gaia/v19/app/sim"
 )
 
 // AppChainID hardcoded chainID for simulation

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/v10/constants.go
+++ b/app/upgrades/v10/constants.go
@@ -1,7 +1,7 @@
 package v10
 
 import (
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v11/constants.go
+++ b/app/upgrades/v11/constants.go
@@ -1,7 +1,7 @@
 package v11
 
 import (
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v12/constants.go
+++ b/app/upgrades/v12/constants.go
@@ -3,7 +3,7 @@ package v12
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v13/constants.go
+++ b/app/upgrades/v13/constants.go
@@ -1,7 +1,7 @@
 package v13
 
 import (
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v13/upgrades.go
+++ b/app/upgrades/v13/upgrades.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v14/constants.go
+++ b/app/upgrades/v14/constants.go
@@ -1,7 +1,7 @@
 package v14
 
 import (
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v14/upgrades.go
+++ b/app/upgrades/v14/upgrades.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v15/constants.go
+++ b/app/upgrades/v15/constants.go
@@ -5,7 +5,7 @@ import (
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v15/upgrades.go
+++ b/app/upgrades/v15/upgrades.go
@@ -27,7 +27,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 // CreateUpgradeHandler returns a upgrade handler for Gaia v15

--- a/app/upgrades/v15/upgrades_test.go
+++ b/app/upgrades/v15/upgrades_test.go
@@ -22,8 +22,8 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/cosmos/gaia/v18/app/helpers"
-	v15 "github.com/cosmos/gaia/v18/app/upgrades/v15"
+	"github.com/cosmos/gaia/v19/app/helpers"
+	v15 "github.com/cosmos/gaia/v19/app/upgrades/v15"
 )
 
 func TestUpgradeSigningInfos(t *testing.T) {

--- a/app/upgrades/v16/constants.go
+++ b/app/upgrades/v16/constants.go
@@ -8,7 +8,7 @@ import (
 
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -18,7 +18,7 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 var RateLimits = map[string]ratelimittypes.MsgAddRateLimit{

--- a/app/upgrades/v16/upgrades_test.go
+++ b/app/upgrades/v16/upgrades_test.go
@@ -17,8 +17,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 
-	"github.com/cosmos/gaia/v18/app/helpers"
-	v16 "github.com/cosmos/gaia/v18/app/upgrades/v16"
+	"github.com/cosmos/gaia/v19/app/helpers"
+	v16 "github.com/cosmos/gaia/v19/app/upgrades/v16"
 )
 
 var AtomSupply = sdkmath.NewInt(1000)

--- a/app/upgrades/v17/constants.go
+++ b/app/upgrades/v17/constants.go
@@ -1,7 +1,7 @@
 package v17
 
 import (
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v17/upgrades.go
+++ b/app/upgrades/v17/upgrades.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v18/constants.go
+++ b/app/upgrades/v18/constants.go
@@ -7,7 +7,7 @@ import (
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v18/upgrades.go
+++ b/app/upgrades/v18/upgrades.go
@@ -14,8 +14,8 @@ import (
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
-	"github.com/cosmos/gaia/v18/types"
+	"github.com/cosmos/gaia/v19/app/keepers"
+	"github.com/cosmos/gaia/v19/types"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v19/constants.go
+++ b/app/upgrades/v19/constants.go
@@ -1,0 +1,15 @@
+package v19
+
+import (
+	"github.com/cosmos/gaia/v19/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v19"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+}

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -1,0 +1,27 @@
+package v19
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/cosmos/gaia/v19/app/keepers"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("Starting module migrations...")
+
+		vm, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return vm, err
+		}
+
+		ctx.Logger().Info("Upgrade v19 complete")
+		return vm, nil
+	}
+}

--- a/app/upgrades/v7/constants.go
+++ b/app/upgrades/v7/constants.go
@@ -6,7 +6,7 @@ import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v7/upgrades.go
+++ b/app/upgrades/v7/upgrades.go
@@ -11,7 +11,7 @@ import (
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v8/constants.go
+++ b/app/upgrades/v8/constants.go
@@ -5,7 +5,7 @@ package v8
 import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -15,7 +15,7 @@ import (
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func FixBankMetadata(ctx sdk.Context, keepers *keepers.AppKeepers) error {

--- a/app/upgrades/v9/constants.go
+++ b/app/upgrades/v9/constants.go
@@ -8,7 +8,7 @@ import (
 
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	"github.com/cosmos/gaia/v18/app/upgrades"
+	"github.com/cosmos/gaia/v19/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v9/upgrades.go
+++ b/app/upgrades/v9/upgrades.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/app/keepers"
+	"github.com/cosmos/gaia/v19/app/keepers"
 )
 
 func CreateUpgradeHandler(

--- a/cmd/gaiad/cmd/bech32_convert.go
+++ b/cmd/gaiad/cmd/bech32_convert.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	addressutil "github.com/cosmos/gaia/v18/pkg/address"
+	addressutil "github.com/cosmos/gaia/v19/pkg/address"
 )
 
 var flagBech32Prefix = "prefix"

--- a/cmd/gaiad/cmd/root.go
+++ b/cmd/gaiad/cmd/root.go
@@ -45,8 +45,8 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	gaia "github.com/cosmos/gaia/v18/app"
-	"github.com/cosmos/gaia/v18/app/params"
+	gaia "github.com/cosmos/gaia/v19/app"
+	"github.com/cosmos/gaia/v19/app/params"
 )
 
 // NewRootCmd creates a new root command for simd. It is called once in the

--- a/cmd/gaiad/cmd/root_test.go
+++ b/cmd/gaiad/cmd/root_test.go
@@ -7,8 +7,8 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	app "github.com/cosmos/gaia/v18/app"
-	"github.com/cosmos/gaia/v18/cmd/gaiad/cmd"
+	app "github.com/cosmos/gaia/v19/app"
+	"github.com/cosmos/gaia/v19/cmd/gaiad/cmd"
 )
 
 func TestRootCmdConfig(t *testing.T) {

--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	gaia "github.com/cosmos/gaia/v18/app"
+	gaia "github.com/cosmos/gaia/v19/app"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 

--- a/cmd/gaiad/main.go
+++ b/cmd/gaiad/main.go
@@ -6,8 +6,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	app "github.com/cosmos/gaia/v18/app"
-	"github.com/cosmos/gaia/v18/cmd/gaiad/cmd"
+	app "github.com/cosmos/gaia/v19/app"
+	"github.com/cosmos/gaia/v19/cmd/gaiad/cmd"
 )
 
 func main() {

--- a/contrib/scripts/upgrade_test_scripts/run_gaia.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_gaia.sh
@@ -63,7 +63,7 @@ tmp=$(mktemp)
 
 # add bank part of genesis
 jq --argjson foo "$(jq -c '.' contrib/denom.json)" '.app_state.bank.denom_metadata = $foo' $NODE_HOME/config/genesis.json >"$tmp" && mv "$tmp" $NODE_HOME/config/genesis.json
-jq ".app_state.gov.params.expedited_voting_period = \"43200s\"" "$NODE_HOME/config/genesis.json" > "$tmp" && mv "$tmp" $NODE_HOME/config/genesis.json
+jq ".app_state.gov.params.expedited_voting_period = \"10s\"" "$NODE_HOME/config/genesis.json" > "$tmp" && mv "$tmp" $NODE_HOME/config/genesis.json
 
 
 # replace default stake token with uatom

--- a/contrib/scripts/upgrade_test_scripts/run_gaia.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_gaia.sh
@@ -63,6 +63,8 @@ tmp=$(mktemp)
 
 # add bank part of genesis
 jq --argjson foo "$(jq -c '.' contrib/denom.json)" '.app_state.bank.denom_metadata = $foo' $NODE_HOME/config/genesis.json >"$tmp" && mv "$tmp" $NODE_HOME/config/genesis.json
+jq ".app_state.gov.params.expedited_voting_period = \"43200s\"" "$NODE_HOME/config/genesis.json" > "$tmp" && mv "$tmp" $NODE_HOME/config/genesis.json
+
 
 # replace default stake token with uatom
 sed -i -e '/total_liquid_staked_tokens/!s/stake/uatom/g' $NODE_HOME/config/genesis.json

--- a/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
@@ -82,7 +82,7 @@ if test -f "$BINARY"; then
     --keyring-backend test \
     --chain-id $CHAINID \
     --home $NODE_HOME \
-    --fees 400uatom \
+    --fees 330000uatom \
     --node tcp://localhost:26657 \
     --yes
 

--- a/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
@@ -65,7 +65,7 @@ if test -f "$BINARY"; then
     --upgrade-info "upgrade" \
     --description "upgrade" \
     --no-validate \
-    --fees 33000uatom \
+    --fees 330000uatom \
     --from val \
     --keyring-backend test \
     --chain-id $CHAINID \

--- a/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
@@ -65,6 +65,8 @@ if test -f "$BINARY"; then
     --upgrade-info "upgrade" \
     --description "upgrade" \
     --no-validate \
+    --gas auto \
+    --gas-adjustment 1.3 \
     --fees 330000uatom \
     --from val \
     --keyring-backend test \
@@ -74,8 +76,7 @@ if test -f "$BINARY"; then
     --yes
   echo "Done \n"
 
-  sleep 3
-  $BINARY q gov proposals  --home $NODE_HOME --node tcp://localhost:26657 --chain-id $CHAINID
+  sleep 6
 
   echo "Casting vote... \n"
 

--- a/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
@@ -65,7 +65,7 @@ if test -f "$BINARY"; then
     --upgrade-info "upgrade" \
     --description "upgrade" \
     --no-validate \
-    --fees 400uatom \
+    --fees 33000uatom \
     --from val \
     --keyring-backend test \
     --chain-id $CHAINID \

--- a/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_upgrade_commands.sh
@@ -74,7 +74,9 @@ if test -f "$BINARY"; then
     --yes
   echo "Done \n"
 
-  sleep 6
+  sleep 3
+  $BINARY q gov proposals  --home $NODE_HOME --node tcp://localhost:26657 --chain-id $CHAINID
+
   echo "Casting vote... \n"
 
   $BINARY tx gov vote 1 yes \

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cosmos/gaia/v18
+module github.com/cosmos/gaia/v19
 
 go 1.22.3
 

--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -25,8 +25,8 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	gaiaparams "github.com/cosmos/gaia/v18/app/params"
-	metaprotocoltypes "github.com/cosmos/gaia/v18/x/metaprotocols/types"
+	gaiaparams "github.com/cosmos/gaia/v19/app/params"
+	metaprotocoltypes "github.com/cosmos/gaia/v19/x/metaprotocols/types"
 )
 
 const (

--- a/tests/e2e/e2e_bank_test.go
+++ b/tests/e2e/e2e_bank_test.go
@@ -10,7 +10,7 @@ import (
 	authTx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	extensiontypes "github.com/cosmos/gaia/v18/x/metaprotocols/types"
+	extensiontypes "github.com/cosmos/gaia/v19/x/metaprotocols/types"
 )
 
 func (s *IntegrationTestSuite) testBankTokenTransfer() {

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -42,7 +42,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/cosmos/gaia/v18/types"
+	"github.com/cosmos/gaia/v19/types"
 )
 
 const (

--- a/tests/e2e/validator.go
+++ b/tests/e2e/validator.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	gaia "github.com/cosmos/gaia/v18/app"
+	gaia "github.com/cosmos/gaia/v19/app"
 )
 
 //

--- a/tests/integration/feemarket_test.go
+++ b/tests/integration/feemarket_test.go
@@ -12,8 +12,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	"github.com/cosmos/gaia/v18/ante"
-	gaiaApp "github.com/cosmos/gaia/v18/app"
+	"github.com/cosmos/gaia/v19/ante"
+	gaiaApp "github.com/cosmos/gaia/v19/app"
 )
 
 const (

--- a/tests/integration/ibcfee_test.go
+++ b/tests/integration/ibcfee_test.go
@@ -12,8 +12,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/cosmos/gaia/v18/ante"
-	gaiaApp "github.com/cosmos/gaia/v18/app"
+	"github.com/cosmos/gaia/v19/ante"
+	gaiaApp "github.com/cosmos/gaia/v19/app"
 )
 
 // These integration tests were modified to work with the GaiaApp

--- a/tests/integration/interchain_security_test.go
+++ b/tests/integration/interchain_security_test.go
@@ -16,8 +16,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/cosmos/gaia/v18/ante"
-	gaiaApp "github.com/cosmos/gaia/v18/app"
+	"github.com/cosmos/gaia/v19/ante"
+	gaiaApp "github.com/cosmos/gaia/v19/app"
 )
 
 var ccvSuite *integration.CCVTestSuite

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -19,7 +19,7 @@ import (
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	gaiaApp "github.com/cosmos/gaia/v18/app"
+	gaiaApp "github.com/cosmos/gaia/v19/app"
 )
 
 var app *gaiaApp.GaiaApp

--- a/x/metaprotocols/module.go
+++ b/x/metaprotocols/module.go
@@ -15,7 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/cosmos/gaia/v18/x/metaprotocols/types"
+	"github.com/cosmos/gaia/v19/x/metaprotocols/types"
 )
 
 const consensusVersion uint64 = 1


### PR DESCRIPTION
Bump gaia app version to `v19`.

This is prerequisite for v50 upgrade.