### PR TITLE
deps: use ibc-apps rate limiter import

### DIFF
--- a/.changelog/unreleased/dependencies/3227-bump-ibc-rate-limits.md
+++ b/.changelog/unreleased/dependencies/3227-bump-ibc-rate-limits.md
@@ -1,0 +1,3 @@
+- Bump [ibc-rate-limiting](https://github.com/cosmos/ibc-apps/blob/main/modules/rate-limiting) to
+    [v8](https://github.com/cosmos/ibc-apps/releases/tag/modules/rate-limiting/v8.0.0)
+    ([\#3227](https://github.com/cosmos/gaia/pull/3227))

--- a/ante/gov_vote_ante.go
+++ b/ante/gov_vote_ante.go
@@ -103,7 +103,6 @@ func (g GovVoteDecorator) ValidateVoteMsgs(ctx sdk.Context, msgs []sdk.Msg) erro
 			// break the iteration if maxDelegationsChecked were already checked
 			return delegationCount >= maxDelegationsChecked
 		})
-
 		if err != nil {
 			return err
 		}

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"strings"
 
-	ratelimit "github.com/cosmos/ibc-apps/modules/rate-limiting/v8"
-	ratelimitkeeper "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/keeper"
-	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	feemarketkeeper "github.com/skip-mev/feemarket/x/feemarket/keeper"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
 	pfmrouter "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward"
 	pfmrouterkeeper "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/keeper"
 	pfmroutertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/types"
+	ratelimit "github.com/cosmos/ibc-apps/modules/rate-limiting/v8"
+	ratelimitkeeper "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/keeper"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	ica "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts"

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 
-	ratelimit "github.com/Stride-Labs/ibc-rate-limiting/ratelimit"
-	ratelimitkeeper "github.com/Stride-Labs/ibc-rate-limiting/ratelimit/keeper"
-	ratelimittypes "github.com/Stride-Labs/ibc-rate-limiting/ratelimit/types"
+	ratelimit "github.com/cosmos/ibc-apps/modules/rate-limiting/v8"
+	ratelimitkeeper "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/keeper"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	feemarketkeeper "github.com/skip-mev/feemarket/x/feemarket/keeper"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
@@ -419,9 +419,9 @@ func NewAppKeeper(
 
 	// Create RateLimit keeper
 	appKeepers.RatelimitKeeper = *ratelimitkeeper.NewKeeper(
-		appCodec,                                 // BinaryCodec
-		appKeepers.keys[ratelimittypes.StoreKey], // StoreKey
-		appKeepers.GetSubspace(ratelimittypes.ModuleName), // param Subspace
+		appCodec, // BinaryCodec
+		runtime.NewKVStoreService(appKeepers.keys[ratelimittypes.StoreKey]), // StoreKey
+		appKeepers.GetSubspace(ratelimittypes.ModuleName),                   // param Subspace
 		govAuthority, // authority
 		appKeepers.BankKeeper,
 		appKeepers.IBCKeeper.ChannelKeeper, // ChannelKeeper

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,7 +1,7 @@
 package keepers
 
 import (
-	ratelimittypes "github.com/Stride-Labs/ibc-rate-limiting/ratelimit/types"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
 	routertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/types"

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,10 +1,10 @@
 package keepers
 
 import (
-	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
 	routertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/types"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"

--- a/app/modules.go
+++ b/app/modules.go
@@ -1,7 +1,7 @@
 package gaia
 
 import (
-	ratelimittypes "github.com/Stride-Labs/ibc-rate-limiting/ratelimit/types"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	feemarket "github.com/skip-mev/feemarket/x/feemarket"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 

--- a/app/modules.go
+++ b/app/modules.go
@@ -1,11 +1,11 @@
 package gaia
 
 import (
-	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	feemarket "github.com/skip-mev/feemarket/x/feemarket"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 
 	pfmroutertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/types"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	"github.com/cosmos/ibc-go/modules/capability"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"

--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -63,7 +63,6 @@ func init() {
 }
 
 func testnetUnsafeStartLocalValidatorCmd(ac appCreator) *cobra.Command {
-
 	cmd := server.StartCmd(ac.newTestingApp, gaia.DefaultNodeHome)
 	cmd.Use = "unsafe-start-local-validator"
 	cmd.Short = "Updates chain's application and consensus state with provided validator info and starts the node"
@@ -167,7 +166,7 @@ func (a appCreator) newTestingApp(
 		panic(err)
 	}
 
-	//Update consensus state
+	// Update consensus state
 	err = updateConsensusState(logger, appOpts, gaiaApp.CommitMultiStore().LatestVersion(), args)
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	cosmossdk.io/x/tx v0.13.3
 	cosmossdk.io/x/upgrade v0.1.4
 	github.com/CosmWasm/wasmd v0.50.0
-	github.com/Stride-Labs/ibc-rate-limiting v0.0.0-20240402205850-be547630b007
 	github.com/cometbft/cometbft v0.38.9
 	github.com/cometbft/cometbft-db v0.12.0
 	github.com/cosmos/cosmos-db v1.0.2
@@ -26,6 +25,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.5.0
 	github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.0.2
+	github.com/cosmos/ibc-apps/modules/rate-limiting/v8 v8.0.0
 	github.com/cosmos/ibc-go/modules/capability v1.0.0
 	github.com/cosmos/ibc-go/v8 v8.3.2
 	github.com/cosmos/interchain-security/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/Stride-Labs/ibc-rate-limiting v0.0.0-20240402205850-be547630b007 h1:6BNsNF5ZI3YPnVq+oJKbtelWoEkuplUzoQH9VTxqHp0=
-github.com/Stride-Labs/ibc-rate-limiting v0.0.0-20240402205850-be547630b007/go.mod h1:r2Mgt9zNLQsUWlx4OhEIzvNm+JE+4fy4h4t6xBAPv5A=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -433,6 +431,8 @@ github.com/cosmos/iavl v1.1.2 h1:zL9FK7C4L/P4IF1Dm5fIwz0WXCnn7Bp1M2FxH0ayM7Y=
 github.com/cosmos/iavl v1.1.2/go.mod h1:jLeUvm6bGT1YutCaL2fIar/8vGUE8cPZvh/gXEWDaDM=
 github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.0.2 h1:dyLNlDElY6+5zW/BT/dO/3Ad9FpQblfh+9dQpYQodbA=
 github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.0.2/go.mod h1:82hPO/tRawbuFad2gPwChvpZ0JEIoNi91LwVneAYCeM=
+github.com/cosmos/ibc-apps/modules/rate-limiting/v8 v8.0.0 h1:AQO9NIAP3RFqvBCj7IqM/V1LCxmuvcvGUdu0RIEz/c0=
+github.com/cosmos/ibc-apps/modules/rate-limiting/v8 v8.0.0/go.mod h1:/ZpKJSW/SKPkFS7jTqkPVn7kOHUUfRNzu+8aS7YOL8o=
 github.com/cosmos/ibc-go/modules/capability v1.0.0 h1:r/l++byFtn7jHYa09zlAdSeevo8ci1mVZNO9+V0xsLE=
 github.com/cosmos/ibc-go/modules/capability v1.0.0/go.mod h1:D81ZxzjZAe0ZO5ambnvn1qedsFQ8lOwtqicG6liLBco=
 github.com/cosmos/ibc-go/v8 v8.3.2 h1:8X1oHHKt2Bh9hcExWS89rntLaCKZp2EjFTUSxKlPhGI=

--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
-
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 
 	dbm "github.com/cosmos/cosmos-db"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 	providertypes "github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
 
 	"cosmossdk.io/log"

--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	ratelimittypes "github.com/Stride-Labs/ibc-rate-limiting/ratelimit/types"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 

--- a/tests/e2e/query.go
+++ b/tests/e2e/query.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
-
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 	providertypes "github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
 

--- a/tests/e2e/query.go
+++ b/tests/e2e/query.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	ratelimittypes "github.com/Stride-Labs/ibc-rate-limiting/ratelimit/types"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 	providertypes "github.com/cosmos/interchain-security/v5/x/ccv/provider/types"


### PR DESCRIPTION
Uses ibc-apps/rate-limiter.

Stride-labs implementation was moved the implementation to ibc-apps repo. This implementation is equivalent to the one from stride, there should be no differences in logic.