### PR TITLE
ci: update goreleaser to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ builds:
     binary: gaiad
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.x86_64.a
     goos:
       - linux
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -114,7 +114,7 @@ builds:
     binary: gaiad
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muslc.aarch64.a
     goos:
       - linux
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 project_name: gaia
 
 env:
@@ -185,7 +186,7 @@ snapshot:
   name_template: SNAPSHOT-{{ .Commit }}
 
 changelog:
-  skip: false
+  disable: false
 
 git:
   # What should be used to sort tags when gathering the current and previous

--- a/Makefile
+++ b/Makefile
@@ -170,14 +170,13 @@ ifneq ($(strip $(TAG)),)
 		-e CGO_ENABLED=1 \
 		-e TM_VERSION=$(TM_VERSION) \
 		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
-		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/gaiad \
 		-w /go/src/gaiad \
 		$(GORELEASER_IMAGE) \
 		release \
 		--snapshot \
 		--skip=publish \
-		--debug \
+		--verbose \
 		--clean
 	@rm -rf dist/
 	@echo "--> Done create-release-dry-run for tag: $(TAG)"
@@ -194,7 +193,6 @@ goreleaser-build-local:
 		-e CGO_ENABLED=1 \
 		-e TM_VERSION=$(TM_VERSION) \
 		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
-		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/gaiad \
 		-w /go/src/gaiad \
 		--platform=linux/amd64 \
@@ -204,7 +202,7 @@ goreleaser-build-local:
 		--skip=publish \
 		--release-notes ./RELEASE_NOTES.md \
 		--timeout 90m \
-		--debug
+		--verbose
 
 # uses goreleaser to create static binaries for linux an darwin
 # requires access to GITHUB_TOKEN which has to be available in the CI environment
@@ -216,7 +214,6 @@ ci-release:
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		-e TM_VERSION=$(TM_VERSION) \
 		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
-		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/gaiad \
 		-w /go/src/gaiad \
 		--platform=linux/amd64 \


### PR DESCRIPTION
Fixes broken release process due to goreleaser versioning.

Ref: https://goreleaser.com/blog/goreleaser-v2/
Deprecations and changes: https://goreleaser.com/deprecations/?h=depre