### PR TITLE
fix: multiple temp directories on command executions

### DIFF
--- a/.changelog/unreleased/bug-fixes/3349-multiple-temp-dirs.md
+++ b/.changelog/unreleased/bug-fixes/3349-multiple-temp-dirs.md
@@ -1,0 +1,2 @@
+- Fix creation of multiple temp directories
+  ([\#3349](https://github.com/cosmos/gaia/pull/3349))

--- a/cmd/gaiad/cmd/root.go
+++ b/cmd/gaiad/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -79,6 +80,9 @@ func NewRootCmd() *cobra.Command {
 	defer func() {
 		if err := tempApplication.Close(); err != nil {
 			panic(err)
+		}
+		if tempDir != gaia.DefaultNodeHome {
+			os.RemoveAll(tempDir)
 		}
 	}()
 
@@ -437,7 +441,7 @@ func (a appCreator) appExport(
 var tempDir = func() string {
 	dir, err := os.MkdirTemp("", ".gaia")
 	if err != nil {
-		dir = gaia.DefaultNodeHome
+		panic(fmt.Sprintf("failed creating temp directory: %s", err.Error()))
 	}
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
## Description

Closes: #3348 

A temporary home directory is created when running gaia, which is not deleted when `pre-instantiation` is finished.
Beside that, in case a temp directory couldn't be created, the default gaia home was returned and deleted! 

This fix:
- deletes the temporary directory once the `temporary bootstrapping` phase is done
- panics in case a temporary home directory canot be created instead of returning default gaia home

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if API, client, or state breaking change (i.e., requires minor or major version bump)
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [x] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
* [x] Added a changelog entry in `.changelog` (for details, see [contributing guidelines](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#changelog))
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
