### PR TITLE
deps!: bump wasmvm to v2.1.3

### DIFF
--- a/.changelog/unreleased/dependencies/-bump-wasmvm-version.md
+++ b/.changelog/unreleased/dependencies/-bump-wasmvm-version.md
@@ -1,0 +1,2 @@
+- Fix submission of broken invariants
+  ([\#3346](https://github.com/cosmos/gaia/pull/3346))

--- a/.changelog/unreleased/dependencies/-bump-wasmvm-version.md
+++ b/.changelog/unreleased/dependencies/-bump-wasmvm-version.md
@@ -1,2 +1,0 @@
-- Fix submission of broken invariants
-  ([\#3346](https://github.com/cosmos/gaia/pull/3346))

--- a/.changelog/unreleased/dependencies/3366-bump-wasmvm-version.md
+++ b/.changelog/unreleased/dependencies/3366-bump-wasmvm-version.md
@@ -1,0 +1,2 @@
+- Update wasmvm to v2.1.3 - security patch
+  ([\#3366](https://github.com/cosmos/gaia/pull/3366))

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ node_modules
 build
 .github
 .vscode
+docs
+.changelog

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    target-branch: "release/v19.2.x"
+    target-branch: "release/v21.x"
     # Only allow automated security-related dependency updates on release branches.
     open-pull-requests-limit: 0
     labels:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,8 +170,8 @@ jobs:
         if: env.GIT_DIFF
       - name: Install New Gaiad
         run: |
-          curl -LO https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm.x86_64.so
-          curl -LO https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm.aarch64.so
+          curl -LO https://github.com/CosmWasm/wasmvm/releases/download/v2.1.3/libwasmvm.x86_64.so
+          curl -LO https://github.com/CosmWasm/wasmvm/releases/download/v2.1.3/libwasmvm.aarch64.so
           uname -m
           sudo cp "./libwasmvm.$(uname -m).so" /usr/lib/
           make build

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,14 +24,14 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           {{ body }}
 
-  - name: Backport patches to the release/v19.2.x branch
+  - name: Backport patches to the release/v21.x branch
     conditions:
       - base=main
-      - label=A:backport/v19.2.x
+      - label=A:backport/v21.x
     actions:
       backport:
         branches:
-          - release/v19.2.x
+          - release/v21.x
 
   - name: Backport patches to the release/v20.x branch
     conditions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ENV PACKAGES="curl make git libc-dev bash file gcc linux-headers eudev-dev"
 RUN apk add --no-cache $PACKAGES
 
 # See https://github.com/CosmWasm/wasmvm/releases
-ARG WASMVM_VERSION=v2.1.2
+ARG WASMVM_VERSION=v2.1.3
 ADD https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 0881c5b463e89e229b06370e9e2961aec0a5c636772d5142c68d351564464a66
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 58e1f6bfa89ee390cb9abc69a5bc126029a497fe09dd399f38a82d0d86fe95ef
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep faea4e15390e046d2ca8441c21a88dba56f9a0363f92c5d94015df0ac6da1f2d
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 8dab08434a5fe57a6fbbcb8041794bc3c31846d31f8ff5fb353ee74e0fcd3093
 RUN cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a
 
 COPY go.mod go.sum* ./

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
-	github.com/CosmWasm/wasmvm/v2 v2.1.2 // indirect
+	github.com/CosmWasm/wasmvm/v2 v2.1.3 // indirect
 	github.com/DataDog/datadog-go v3.2.0+incompatible // indirect
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CosmWasm/wasmd v0.53.0 h1:kdaoAi20bIb4VCsxw9pRaT2g5PpIp82Wqrr9DRVN9ao=
 github.com/CosmWasm/wasmd v0.53.0/go.mod h1:FJl/aWjdpGof3usAMFQpDe07Rkx77PUzp0cygFMOvtw=
-github.com/CosmWasm/wasmvm/v2 v2.1.2 h1:GkJ5bAsRlLHfIQVg/FY1VHwLyBwlCjAhDea0B8L+e20=
-github.com/CosmWasm/wasmvm/v2 v2.1.2/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
+github.com/CosmWasm/wasmvm/v2 v2.1.3 h1:CSJTauZqkHyb9yic6JVYCjiGUgxI2MJV2QzfSu8m49c=
+github.com/CosmWasm/wasmvm/v2 v2.1.3/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Closes: https://github.com/cosmos/gaia/issues/3365

Added v21.x to bots while I was at it.