### PR TITLE
fix!: add missing gov v5 migration section

### DIFF
--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	"github.com/cosmos/gaia/v21/app/keepers"
 )
 
@@ -28,4 +29,11 @@ func CreateUpgradeHandler(
 		ctx.Logger().Info("Upgrade v21 complete")
 		return vm, nil
 	}
+}
+
+// setting the default constitution for the chain
+// this is in line with cosmos-sdk v5 gov migration: https://github.com/cosmos/cosmos-sdk/blob/v0.50.10/x/gov/migrations/v5/store.go#L57
+func InitializeConstitutionCollection(ctx sdk.Context, govKeeper govkeeper.Keeper) error {
+	govKeeper.Constitution.Set(ctx, "This chain has no constitution.")
+	return nil
 }

--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -7,8 +7,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+
 	"github.com/cosmos/gaia/v21/app/keepers"
 )
 
@@ -26,6 +26,11 @@ func CreateUpgradeHandler(
 			return vm, err
 		}
 
+		err = InitializeConstitutionCollection(ctx, *keepers.GovKeeper)
+		if err != nil {
+			ctx.Logger().Error("Error initializing Constitution Collection:", "message", err.Error())
+		}
+
 		ctx.Logger().Info("Upgrade v21 complete")
 		return vm, nil
 	}
@@ -34,6 +39,5 @@ func CreateUpgradeHandler(
 // setting the default constitution for the chain
 // this is in line with cosmos-sdk v5 gov migration: https://github.com/cosmos/cosmos-sdk/blob/v0.50.10/x/gov/migrations/v5/store.go#L57
 func InitializeConstitutionCollection(ctx sdk.Context, govKeeper govkeeper.Keeper) error {
-	govKeeper.Constitution.Set(ctx, "This chain has no constitution.")
-	return nil
+	return govKeeper.Constitution.Set(ctx, "This chain has no constitution.")
 }

--- a/app/upgrades/v21/upgrades_test.go
+++ b/app/upgrades/v21/upgrades_test.go
@@ -1,0 +1,25 @@
+package v21_test
+
+import (
+	"testing"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/gaia/v21/app/helpers"
+	v21 "github.com/cosmos/gaia/v21/app/upgrades/v21"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeConstitutionCollection(t *testing.T) {
+	gaiaApp := helpers.Setup(t)
+	ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{})
+
+	govKeeper := gaiaApp.GovKeeper
+
+	pre, err := govKeeper.Constitution.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", pre)
+	v21.InitializeConstitutionCollection(ctx, *govKeeper)
+	post, err := govKeeper.Constitution.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "This chain has no constitution.", post)
+}

--- a/app/upgrades/v21/upgrades_test.go
+++ b/app/upgrades/v21/upgrades_test.go
@@ -3,10 +3,12 @@ package v21_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
 	"github.com/cosmos/gaia/v21/app/helpers"
 	v21 "github.com/cosmos/gaia/v21/app/upgrades/v21"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInitializeConstitutionCollection(t *testing.T) {
@@ -18,7 +20,8 @@ func TestInitializeConstitutionCollection(t *testing.T) {
 	pre, err := govKeeper.Constitution.Get(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "", pre)
-	v21.InitializeConstitutionCollection(ctx, *govKeeper)
+	err = v21.InitializeConstitutionCollection(ctx, *govKeeper)
+	require.NoError(t, err)
 	post, err := govKeeper.Constitution.Get(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "This chain has no constitution.", post)

--- a/cmd/gaiad/cmd/README.md
+++ b/cmd/gaiad/cmd/README.md
@@ -11,7 +11,7 @@ The command is added as a sub-command of the `gaiad testnet` command.
 The gaia binary will contain the testnet extensions only if the `unsafe_start_local_validator` build tags is used.
 
 ```shell
-make build BUILD_TAGS="-tag unsafe_start_local_validator"
+make build BUILD_TAGS="unsafe_start_local_validator"
 ```
 
 ## CLI usage
@@ -45,7 +45,7 @@ gaiad keys parse $(gaiad keys parse $VAL_ACC_ADDR --output=json | jq .bytes -r) 
 }
 
 # --validator-pubkey and --validator-privkey are in`$HOME/.gaia/config/priv_validator.json
-cat $HOME/.gaia/config/priv_validator.json
+cat $HOME/.gaia/config/priv_validator_key.json
 {
   "address": "067CC9545EC0CD744C44D611E3E8857D69E9CAD4",
   "pub_key": {
@@ -59,6 +59,8 @@ cat $HOME/.gaia/config/priv_validator.json
 }
 ```
 
+You will also need to change your chain-id in `genesis.json` to match the chain-id of the network you are using in testing (e.g. `cosmoshub-4`).
+This is because `gaiad init` creates a `genesis.json` with a testing chain id.
 
 ## Example usecase
 


### PR DESCRIPTION
Context:
https://github.com/cosmos/gaia/issues/3374

Gaia backported expedited proposal to sdk v0.47.
cosmos-sdk v47 did not include the constitution section, it's a new addition for v50.