### PR TITLE
test: fix unsafe-start-local-validator command

### DIFF
--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -269,6 +269,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 	// PROVIDER
 	app.ProviderKeeper.DeleteLastProviderConsensusValSet(appCtx)
 
+        // GOVERNANCE
 	shortVotingPeriod := time.Second * 20
 	expeditedVotingPeriod := time.Second * 10
 	params, err := app.GovKeeper.Params.Get(appCtx)

--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -266,6 +266,9 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 
 	app.SlashingKeeper.SetValidatorSigningInfo(appCtx, newConsAddr, newValidatorSigningInfo)
 
+	// PROVIDER
+	app.ProviderKeeper.DeleteLastProviderConsensusValSet(appCtx)
+
 	shortVotingPeriod := time.Second * 20
 	expeditedVotingPeriod := time.Second * 10
 	params, err := app.GovKeeper.Params.Get(appCtx)


### PR DESCRIPTION
Closes #3372 
unsafe-start-local-validator is updated with the code that clears provider state related to old validators