### PR TITLE
improve log readability

### DIFF
--- a/cmd/gaiad/cmd/README.md
+++ b/cmd/gaiad/cmd/README.md
@@ -67,3 +67,6 @@ This is because `gaiad init` creates a `genesis.json` with a testing chain id.
 2. replace all validator key files (keyring data, `priv_validator_key.json`, values in `priv_validator_state.json` are reset to 0...)
 3. run `gaiad testnet unsafe-start-local-validator` -> switches the validator set and starts the node
 
+## Optional Cleanup for Log Readability
+
+It's recommended to delete the contents of the data/cs.wal folder (from the mainnet node snapshot) before running the unsafe-start-local-validator command. This folder stores messages used for replaying, which are no longer needed since a new block will be created with the new validator setup. If not deleted, the logs may contain misleading errors related to the old state. While this deletion is not mandatory, it can help improve log readability and reduce confusion during testing.


### PR DESCRIPTION
This pr adds a section in readme file related to unsafe-start-local-validator command. The section describes how to prevent logging of misleading log messages that might appear if some node msgs are attempt to be replayed to the blockchain. Since we don't need this replay data because we are creating new block with the new(replaced validator), the content can be deleted and the log wont show the error logs similar to this:

_2:52PM INF Replay: Vote blockID=C80F67CDC3EFDB6E3496605908EFBDEA0A73E58315E9B34A3491C3383702D8F4:1:5ED0B863FBFA extSigLen=0 extensionLen=0 height=22453073 module=consensus peer=7314c477c9d7fea4e2ebf51581f2324971260494 round=0 type=SIGNED_MSG_TYPE_PRECOMMIT
2:52PM INF failed attempting to add vote err="cannot find validator 151 in valSet of size 1: invalid validator index" module=consensus
2:52PM ERR failed to process message err="error adding vote" height=22453074 module=consensus msg_type=*consensus.VoteMessage peer=7314c477c9d7fea4e2ebf51581f2324971260494 round=0_