### PR TITLE
fix!: add missing gov v5 migration param section

### DIFF
--- a/.changelog/unreleased/bug-fixes/3387-add-gov-v5-params.md
+++ b/.changelog/unreleased/bug-fixes/3387-add-gov-v5-params.md
@@ -1,0 +1,2 @@
+- Initialize uninitialized governance params
+  ([\#3387](https://github.com/cosmos/gaia/pull/3387))

--- a/app/upgrades/v21/upgrades.go
+++ b/app/upgrades/v21/upgrades.go
@@ -16,6 +16,7 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govparams "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
 	"github.com/cosmos/gaia/v21/app/keepers"
 )
@@ -61,6 +62,11 @@ func CreateUpgradeHandler(
 		err = InitializeConstitutionCollection(ctx, *keepers.GovKeeper)
 		if err != nil {
 			ctx.Logger().Error("Error initializing Constitution Collection:", "message", err.Error())
+		}
+
+		err = InitializeGovParams(ctx, *keepers.GovKeeper)
+		if err != nil {
+			ctx.Logger().Error("Error initializing Gov Params:", "message", err.Error())
 		}
 
 		ctx.Logger().Info("Upgrade v21 complete")
@@ -132,4 +138,16 @@ func AllocateNeutronAndStrideUnaccountedDenoms(ctx sdk.Context, providerKeeper p
 // this is in line with cosmos-sdk v5 gov migration: https://github.com/cosmos/cosmos-sdk/blob/v0.50.10/x/gov/migrations/v5/store.go#L57
 func InitializeConstitutionCollection(ctx sdk.Context, govKeeper govkeeper.Keeper) error {
 	return govKeeper.Constitution.Set(ctx, "This chain has no constitution.")
+}
+
+func InitializeGovParams(ctx sdk.Context, govKeeper govkeeper.Keeper) error {
+	params, err := govKeeper.Params.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	params.ProposalCancelRatio = govparams.DefaultProposalCancelRatio.String()
+	params.ProposalCancelDest = govparams.DefaultProposalCancelDestAddress
+
+	return govKeeper.Params.Set(ctx, params)
 }

--- a/app/upgrades/v21/upgrades_test.go
+++ b/app/upgrades/v21/upgrades_test.go
@@ -7,6 +7,7 @@ import (
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
+	govparams "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/gaia/v21/app/helpers"
 	v21 "github.com/cosmos/gaia/v21/app/upgrades/v21"
 )
@@ -43,4 +44,38 @@ func TestInitializeConstitutionCollection(t *testing.T) {
 	post, err := govKeeper.Constitution.Get(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "This chain has no constitution.", post)
+}
+
+func TestInitializeGovParams(t *testing.T) {
+	gaiaApp := helpers.Setup(t)
+	ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{})
+
+	govKeeper := gaiaApp.GovKeeper
+
+	// sets the params to "" so we can confirm that the migration
+	// function actually changes the parameter to 0.5 from ""
+	setupParams, err := govKeeper.Params.Get(ctx)
+	require.NoError(t, err)
+	setupParams.ProposalCancelRatio = "" // mainnet value
+	setupParams.ProposalCancelDest = ""  // mainnet value
+	if err := govKeeper.Params.Set(ctx, setupParams); err != nil {
+		t.Fatalf("error setting params: %s", err)
+	}
+
+	pre, err := govKeeper.Params.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", pre.ProposalCancelRatio) // mainnet value
+	require.NotEqual(t, govparams.DefaultProposalCancelRatio.String(), pre.ProposalCancelRatio)
+
+	err = v21.InitializeGovParams(ctx, *govKeeper)
+	require.NoError(t, err)
+
+	post, err := govKeeper.Params.Get(ctx)
+	require.NoError(t, err)
+
+	require.NotEqual(t, pre.ProposalCancelRatio, post.ProposalCancelRatio)
+	require.Equal(t, govparams.DefaultProposalCancelRatio.String(), post.ProposalCancelRatio) // confirm change to sdk default
+
+	require.Equal(t, pre.ProposalCancelDest, post.ProposalCancelDest) // does not change (it was already default)
+	require.Equal(t, "", post.ProposalCancelDest)
 }

--- a/app/upgrades/v21/upgrades_test.go
+++ b/app/upgrades/v21/upgrades_test.go
@@ -8,6 +8,7 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	govparams "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
 	"github.com/cosmos/gaia/v21/app/helpers"
 	v21 "github.com/cosmos/gaia/v21/app/upgrades/v21"
 )


### PR DESCRIPTION
Initializes gov `ProposalCancelRatio` and `ProposalCancelDest` to sdk defaults.

The values are currently not initialized on mainnet.