### PR TITLE
fix(ci): Bump interchaintest packages to v22

### DIFF
--- a/tests/interchain/delegator/evidence_test.go
+++ b/tests/interchain/delegator/evidence_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/gaia/v21/tests/interchain/chainsuite"
-	"github.com/cosmos/gaia/v21/tests/interchain/delegator"
+	"github.com/cosmos/gaia/v22/tests/interchain/chainsuite"
+	"github.com/cosmos/gaia/v22/tests/interchain/delegator"
 	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/suite"

--- a/tests/interchain/delegator/gov_test.go
+++ b/tests/interchain/delegator/gov_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
-	"github.com/cosmos/gaia/v21/tests/interchain/chainsuite"
-	"github.com/cosmos/gaia/v21/tests/interchain/delegator"
+	"github.com/cosmos/gaia/v22/tests/interchain/chainsuite"
+	"github.com/cosmos/gaia/v22/tests/interchain/delegator"
 	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )

--- a/tests/interchain/matrix_tool/main.go
+++ b/tests/interchain/matrix_tool/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -96,9 +97,11 @@ func GetSemverForBranch() (string, error) {
 
 func GetTestList() ([]string, error) {
 	retval := []string{}
-	out, err := exec.Command("go", "test", "-list=.", "./...").Output()
+	cmd := exec.Command("go", "test", "-list=.", "./...")
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("go test -list failed: %w\n", err)
+		stderr := string(cmd.Stderr.(*bytes.Buffer).Bytes())
+		return nil, fmt.Errorf("go test -list failed with %w : %s\n", err, stderr)
 	}
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {


### PR DESCRIPTION
## Description

Interchaintests are currently busted in main 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed
