### PR TITLE
fix typo Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,7 +416,7 @@
 
 ### BUG FIXES
 
-- Increase x/gov metadata fields legth to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
+- Increase x/gov metadata fields length to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
 - Fix parsing of historic Txs with TxExtensionOptions ([\#3032](https://github.com/cosmos/gaia/pull/3032))
 
 ### STATE BREAKING


### PR DESCRIPTION
## Pull Request Title
fix: typo in CHANGELOG.md

### Description
This pull request corrects a typographical error in the `CHANGELOG.md` file:
- Replaced "legth" with "length" to fix the spelling mistake.

### Changes Made
- Corrected the typo in the **BUG FIXES** section of the changelog.

### Related Issues
- N/A (or reference any related issues if applicable)

### Additional Notes
- This change improves the accuracy and professionalism of the documentation.
