### PR TITLE
fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1217,7 +1217,7 @@ See the [Tendermint v0.34.7 SDK changelog](https://github.com/tendermint/tenderm
 * (sdk) Update SDK version to v0.36.0
 * (gaiad) [\#3985](https://github.com/cosmos/cosmos-sdk/issues/3985) ValidatorPowerRank uses potential consensus power
 * (gaiad) [\#4027](https://github.com/cosmos/cosmos-sdk/issues/4027) gaiad version command does not return the checksum of the go.sum file shipped along with the source release tarball.
-  Go modules feature guarantees dependencies reproducibility and as long as binaries are built via the Makefile shipped with the sources, no dependendencies can break such guarantee.
+  Go modules feature guarantees dependencies reproducibility and as long as binaries are built via the Makefile shipped with the sources, no dependencies can break such guarantee.
 * (gaiad) [\#4159](https://github.com/cosmos/cosmos-sdk/issues/4159) use module pattern and module manager for initialization
 * (gaiad) [\#4272](https://github.com/cosmos/cosmos-sdk/issues/4272) Merge gaiareplay functionality into gaiad replay.
   Drop `gaiareplay` in favor of new `gaiad replay` command.


### PR DESCRIPTION
# Fix CHANGELOG.md

## Summary
Corrected a typo in the `CHANGELOG.md` file to improve readability and ensure accuracy.

## Motivation
The correction ensures the changelog is clear and free from errors, which is important for maintaining the project's professionalism.

## Changes
- Updated `CHANGELOG.md`:
  - Corrected the phrase "no dependendencies" to "no dependencies" in the following entry:
    ```markdown
    Go modules feature guarantees dependencies reproducibility and as long as binaries are built via the Makefile shipped with the sources, no dependencies can break such guarantee.
    ```

## Testing
- Manually reviewed the changelog to ensure the typo was fixed.
- Verified no other issues were introduced.

## Checklist
- [x] Typo corrected in the changelog.
- [ ] No additional updates needed.

---

<!-- Contributions are in accordance with the project's contributing guidelines and security policy. -->
