### PR TITLE
Typos fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,12 +456,12 @@
 
 ### BUG FIXES
 
-- Increase x/gov metadata fields legth to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
+- Increase x/gov metadata fields length to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
 - Fix parsing of historic Txs with TxExtensionOptions ([\#3032](https://github.com/cosmos/gaia/pull/3032))
 
 ### STATE BREAKING
 
-- Increase x/gov metadata fields legth to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
+- Increase x/gov metadata fields length to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
 - Fix parsing of historic Txs with TxExtensionOptions ([\#3032](https://github.com/cosmos/gaia/pull/3032))
 
 ## v15.1.0
@@ -1257,7 +1257,7 @@ See the [Tendermint v0.34.7 SDK changelog](https://github.com/tendermint/tenderm
 * (sdk) Update SDK version to v0.36.0
 * (gaiad) [\#3985](https://github.com/cosmos/cosmos-sdk/issues/3985) ValidatorPowerRank uses potential consensus power
 * (gaiad) [\#4027](https://github.com/cosmos/cosmos-sdk/issues/4027) gaiad version command does not return the checksum of the go.sum file shipped along with the source release tarball.
-  Go modules feature guarantees dependencies reproducibility and as long as binaries are built via the Makefile shipped with the sources, no dependendencies can break such guarantee.
+  Go modules feature guarantees dependencies reproducibility and as long as binaries are built via the Makefile shipped with the sources, no dependencies can break such guarantee.
 * (gaiad) [\#4159](https://github.com/cosmos/cosmos-sdk/issues/4159) use module pattern and module manager for initialization
 * (gaiad) [\#4272](https://github.com/cosmos/cosmos-sdk/issues/4272) Merge gaiareplay functionality into gaiad replay.
   Drop `gaiareplay` in favor of new `gaiad replay` command.

--- a/docs/docs/architecture/adr/PROCESS.md
+++ b/docs/docs/architecture/adr/PROCESS.md
@@ -48,7 +48,7 @@ flowchart TD
 * `LAST CALL <date for the last call>`: [optional] clear notify that we are close to accept updates. Changing a status to `LAST CALL` means that social consensus (of Cosmos SDK maintainers) has been reached and we still want to give it a time to let the community react or analyze.
 * `ACCEPTED`: ADR which will represent a currently implemented or to be implemented architecture design.
 * `REJECTED`: ADR can go from PROPOSED or ACCEPTED to rejected if the consensus among project stakeholders will decide so.
-* `SUPERSEEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
+* `SUPERSEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
 * `ABANDONED`: the ADR is no longer pursued by the original authors.
 
 ## Language used in ADR


### PR DESCRIPTION
### Changes

1. **File:** `/CHANGELOG.md`
    - Fixed `legth` to `length` (Line 459)
    - Fixed `dependendencies` to `dependencies` (Line 1260)
1. **File:** `/docs/docs/architecture/adr/PROCESS.md`
    - Fixed `SUPERSEEDED` to `SUPERSEDED` (Line 51)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.