### PR TITLE
Fixed typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,12 +416,12 @@
 
 ### BUG FIXES
 
-- Increase x/gov metadata fields legth to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
+- Increase x/gov metadata fields length to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
 - Fix parsing of historic Txs with TxExtensionOptions ([\#3032](https://github.com/cosmos/gaia/pull/3032))
 
 ### STATE BREAKING
 
-- Increase x/gov metadata fields legth to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
+- Increase x/gov metadata fields length to 10200 ([\#3025](https://github.com/cosmos/gaia/pull/3025))
 - Fix parsing of historic Txs with TxExtensionOptions ([\#3032](https://github.com/cosmos/gaia/pull/3032))
 
 ## v15.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ When testing a function under a variety of different inputs, we prefer to use
 [table driven tests](https://github.com/golang/go/wiki/TableDrivenTests).
 Table driven test error messages should follow the following format
 `<desc>, tc #<index>, i #<index>`.
-`<desc>` is an optional short description of whats failing, `tc` is the
+`<desc>` is an optional short description of what's failing, `tc` is the
 index within the table of the testcase that is failing, and `i` is when there
 is a loop, exactly which iteration of the loop failed.
 The idea is you should be able to see the


### PR DESCRIPTION
### Changes

1. **File:** `/CHANGELOG.md`
    - Fixed `legth` to `length` (Line 464)
1. **File:** `/CONTRIBUTING.md`
    - Fixed `whats` to `what's` (Line 154)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.