### PR TITLE
chore: Update main changelog for v22.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### BUG-FIXES
 
-### STATE-BREAKING
+### STATE BREAKING
 
 ### API-BREAKING
 
@@ -26,7 +26,14 @@
 ### DEPENDENCIES
 - Bump [ibc-apps/middleware/packet-forward-middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) to
     [v8.1.1](https://github.com/cosmos/ibc-apps/releases/tag/middleware%2Fpacket-forward-middleware%2Fv8.1.1)
-    ([\#3533](https://github.com/cosmos/gaia/pull/3533))
+    ([\#3534](https://github.com/cosmos/gaia/pull/3534))
+- Add `v22.2.0` upgrade handler ([\#3538](https://github.com/cosmos/gaia/pull/3538))
+
+### STATE BREAKING
+- Bump [ibc-apps/middleware/packet-forward-middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) to
+    [v8.1.1](https://github.com/cosmos/ibc-apps/releases/tag/middleware%2Fpacket-forward-middleware%2Fv8.1.1)
+    ([\#3534](https://github.com/cosmos/gaia/pull/3534))
+- Add `v22.2.0` upgrade handler ([\#3538](https://github.com/cosmos/gaia/pull/3538))
 
 ## v22.1.0
 
@@ -40,7 +47,7 @@ February 10, 2025
   [v0.38.17](https://github.com/cometbft/cometbft/releases/tag/v0.38.17)
   ([\#3523](https://github.com/cosmos/gaia/pull/3523))
 
-### STATE-BREAKING
+### STATE BREAKING
 - Bump [wasmvm](https://github.com/CosmWasm/wasmvm) to
   [v2.1.5](https://github.com/CosmWasm/wasmvm/releases/tag/v2.1.5)
   ([\#3519](https://github.com/cosmos/gaia/pull/3519))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## UNRELEASED
 
 ### DEPENDENCIES
-- Bump [ibc-apps/middleware/packet-forward-middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) to
-    [v8.1.1](https://github.com/cosmos/ibc-apps/releases/tag/middleware%2Fpacket-forward-middleware%2Fv8.1.1)
-    ([\#3533](https://github.com/cosmos/gaia/pull/3533))
 
 ### BUG FIXES
 - Export only validators that are participating in consensus
@@ -22,18 +19,31 @@
 
 ### API-BREAKING
 
-## v22.0.1
+## v22.2.0
 
-*February 7, 2025*
+*February 12, 2025*
 
 ### DEPENDENCIES
+- Bump [ibc-apps/middleware/packet-forward-middleware](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware) to
+    [v8.1.1](https://github.com/cosmos/ibc-apps/releases/tag/middleware%2Fpacket-forward-middleware%2Fv8.1.1)
+    ([\#3533](https://github.com/cosmos/gaia/pull/3533))
 
+## v22.1.0
+
+February 10, 2025
+
+### DEPENDENCIES
 - Bump [wasmvm](https://github.com/CosmWasm/wasmvm) to
   [v2.1.5](https://github.com/CosmWasm/wasmvm/releases/tag/v2.1.5)
   ([\#3519](https://github.com/cosmos/gaia/pull/3519))
 - Bump [cometbft](https://github.com/cometbft/cometbft) to
   [v0.38.17](https://github.com/cometbft/cometbft/releases/tag/v0.38.17)
   ([\#3523](https://github.com/cosmos/gaia/pull/3523))
+
+### STATE-BREAKING
+- Bump [wasmvm](https://github.com/CosmWasm/wasmvm) to
+  [v2.1.5](https://github.com/CosmWasm/wasmvm/releases/tag/v2.1.5)
+  ([\#3519](https://github.com/cosmos/gaia/pull/3519))
 
 ## v22.0.0
 


### PR DESCRIPTION
Update main changelog after v22.2.0 release