### PR TITLE
chore: add v22.2.0 upgrade handler

### DIFF
--- a/app/upgrades/v22_2_0/constants.go
+++ b/app/upgrades/v22_2_0/constants.go
@@ -1,0 +1,15 @@
+package v22_2_0 //nolint:revive
+
+import (
+	"github.com/cosmos/gaia/v23/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v22.2.0"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+}

--- a/app/upgrades/v22_2_0/upgrades.go
+++ b/app/upgrades/v22_2_0/upgrades.go
@@ -1,0 +1,31 @@
+package v22_2_0 //nolint:revive
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/cosmos/gaia/v23/app/keepers"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(c)
+		ctx.Logger().Info("Starting module migrations...")
+
+		vm, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return vm, err
+		}
+
+		ctx.Logger().Info("Upgrade v22.2.0 complete")
+		return vm, nil
+	}
+}

--- a/contrib/scripts/upgrade_test_scripts/run_gaia.sh
+++ b/contrib/scripts/upgrade_test_scripts/run_gaia.sh
@@ -1,29 +1,44 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit -o nounset
 
 # find the highest upgrade version number($UPGRADE_VERSION_NUMBER) within the 'app/upgrades' dir.
 # the highest upgrade version is used to propose upgrade and create /cosmovisor/upgrades/$UPGRADE_VERSION/bin dir.
 UPGRADES_DIR=$(realpath ./app/upgrades)
-UPGRADE_VERSION_NUMBER=0
+UPGRADE_VERSION="v0"
+
+version_gt() {
+  IFS='_' read -ra LEFT_PARTS <<< "${1#v}"
+  IFS='_' read -ra RIGHT_PARTS <<< "${2#v}"
+
+  for ((i=0; i < ${#LEFT_PARTS[@]} || i < ${#RIGHT_PARTS[@]}; i++)); do
+    LEFT_NUM=${LEFT_PARTS[i]:-0}  # Default to 0 if missing
+    RIGHT_NUM=${RIGHT_PARTS[i]:-0} # Default to 0 if missing
+
+    if (( LEFT_NUM > RIGHT_NUM )); then
+      return 0  # Left is greater
+    elif (( LEFT_NUM < RIGHT_NUM )); then
+      return 1  # Right is greater
+    fi
+  done
+
+  return 1  # Equal versions, so not greater
+}
 
 for dir in "$UPGRADES_DIR"/*; do
   if [ -d "$dir" ]; then
     DIR_NAME=$(basename "$dir")
-    VERSION_NUMBER="${DIR_NAME#v}"
-    if [ "$VERSION_NUMBER" -gt "$UPGRADE_VERSION_NUMBER" ]; then
-      UPGRADE_VERSION_NUMBER=$VERSION_NUMBER
+
+    if version_gt "$DIR_NAME" "$UPGRADE_VERSION"; then
+      UPGRADE_VERSION="$DIR_NAME"
     fi
   fi
 done
 
-if [ -n "$UPGRADE_VERSION_NUMBER" ]; then
-  echo "Upgrade to version: $UPGRADE_VERSION_NUMBER"
-else
-  echo "No upgrade version found in app/upgrades."
-fi
+# Convert "_" to "." in the final output
+UPGRADE_VERSION="${UPGRADE_VERSION//_/.}"
 
-UPGRADE_VERSION=v$UPGRADE_VERSION_NUMBER
+echo "Latest upgrade version: $UPGRADE_VERSION"
 NODE_HOME=$(realpath ./build/.gaia)
 echo "NODE_HOME = ${NODE_HOME}"
 BINARY=$NODE_HOME/cosmovisor/genesis/bin/gaiad
@@ -41,6 +56,7 @@ rm -rf ./build/.gaia
 
 mkdir -p "$NODE_HOME"/cosmovisor/genesis/bin
 cp ./build/gaiadold "$NODE_HOME"/cosmovisor/genesis/bin/gaiad
+chmod a+x $BINARY
 $BINARY init upgrader --chain-id $CHAINID --home "$NODE_HOME"
 
 if ! test -f "./build/gaiadnew"; then
@@ -50,6 +66,7 @@ fi
 
 mkdir -p "$NODE_HOME"/cosmovisor/upgrades/$UPGRADE_VERSION/bin
 cp ./build/gaiadnew "$NODE_HOME"/cosmovisor/upgrades/$UPGRADE_VERSION/bin/gaiad
+chmod a+x "$NODE_HOME"/cosmovisor/upgrades/$UPGRADE_VERSION/bin/gaiad
 
 GOPATH=$(go env GOPATH)
 


### PR DESCRIPTION
backport the v22.2.0 upgrade handler to main, which already has v23 upgrade wired up in app.go