### PR TITLE
fix: linux release build version missing v

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,7 @@ builds:
       - linux
     goarch:
       - amd64
+    mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - muslc
       - ledger
@@ -108,7 +109,7 @@ builds:
       - -X main.date={{ .CommitDate }}
       - -X github.com/cosmos/cosmos-sdk/version.Name=gaia
       - -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad
-      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
       - -X github.com/cosmos/cosmos-sdk/version.BuildTags=muslc,ledger
       - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}


### PR DESCRIPTION
linux-amd64 automated release build is missing v in the version
also missing the mod_timestamp which is in the other builds