### PR TITLE
chore: Fix e2e test imports

### DIFF
--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -11,7 +11,7 @@ import (
 
 	dbm "github.com/cosmos/cosmos-db"
 	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
-	wasmclienttypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	wasmclienttypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
 	providertypes "github.com/cosmos/interchain-security/v7/x/ccv/provider/types"
 
 	"cosmossdk.io/log"

--- a/tests/e2e/query.go
+++ b/tests/e2e/query.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
-	wasmclienttypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	wasmclienttypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
 	icacontrollertypes "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/controller/types"
 	providertypes "github.com/cosmos/interchain-security/v7/x/ccv/provider/types"
 


### PR DESCRIPTION
Fixes e2e test imports.

Ended up merging the new e2e tests which were broken by the recent wasm client version bumps.
https://github.com/cosmos/gaia/commit/4ab7d6c51cdda0e1fb2d4cdfae30a8900dff6d21
https://github.com/cosmos/gaia/commit/00286ae27d2c571b22b4c0a476c90ac38f63612e