### PR TITLE
docs: fix broken link in PR template `production.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/production.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production.md
@@ -24,7 +24,7 @@ I have...
 * [ ] Added `!` to the type prefix if API, client, or state breaking change (i.e., requires minor or major version bump)
 * [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
 * [ ] Provided a link to the relevant issue or specification
-* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
+* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/tree/main/docs/build/building-modules)
 * [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#testing)
 * [ ] Added a changelog entry in `.changelog` (for details, see [contributing guidelines](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#changelog))
 * [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)


### PR DESCRIPTION
Hi! The link to the "building SDK modules" guidelines in the pull request template was broken. The old URL (`https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules`) returned a 404 error due to repository path restructuring.