### PR TITLE
fix: fix incorrect error return in `ExportAppStateAndValidators`

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -61,7 +61,7 @@ func (app *GaiaApp) ExportAppStateAndValidators(
 		Validators:      validators,
 		Height:          height,
 		ConsensusParams: app.BaseApp.GetConsensusParams(ctx),
-	}, err
+	}, nil
 }
 
 // prepare for fresh start at zero height


### PR DESCRIPTION
I fixed an issue in the `ExportAppStateAndValidators` function where the `err` variable was incorrectly returned. The variable is already handled inside the function and should not be returned. Instead of returning `err` in the following line:

```go
}, err
```

I replaced it with `nil` to ensure that when there is no error, we return the correct type (`error`), which should be `nil` in this case.