### PR TITLE
refactor: Improve proto generation script reliability

### DIFF
--- a/proto/scripts/protocgen.sh
+++ b/proto/scripts/protocgen.sh
@@ -2,16 +2,21 @@
 
 set -eo pipefail
 echo "Generating gogo proto code"
+
 cd proto
-proto_dirs=$(find ./ -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+
+proto_dirs=$(find . -name '*.proto' -print0 | xargs -0 -n1 dirname | sort -u)
+
 for dir in $proto_dirs; do
-  for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
-    if grep "option go_package" $file &> /dev/null ; then
-      buf generate --template buf.gen.gogo.yaml $file
+  for file in "$dir"/*.proto; do
+    if grep -q "option go_package" "$file"; then
+      buf generate --template buf.gen.gogo.yaml "$file"
     fi
   done
 done
+
 cd ..
+
 # move proto files to the right places
 cp -r github.com/cosmos/gaia/* ./
 rm -rf github.com


### PR DESCRIPTION
I noticed a few inefficiencies in the proto generation script and made some improvements:  

- Removed `-path -prune`, as it had no effect.  
- Replaced `sort | uniq` with `sort -u` for better efficiency.  
- Added quotes around `"$file"` to prevent issues with spaces in paths.  
- Used `grep -q` instead of redirecting output to `/dev/null` for cleaner code.  
