### PR TITLE
chore: correct error message wording

### DIFF
--- a/cmd/gaiad/cmd/bech32_convert.go
+++ b/cmd/gaiad/cmd/bech32_convert.go
@@ -32,7 +32,7 @@ Example:
 			address := args[0]
 			convertedAddress, err := addressutil.ConvertBech32Prefix(address, bech32prefix)
 			if err != nil {
-				return fmt.Errorf("conversation failed: %s", err)
+				return fmt.Errorf("conversion failed: %s", err)
 			}
 
 			cmd.Println(convertedAddress)


### PR DESCRIPTION
The error message now correctly uses "conversion" instead of "conversation" to match the context of Bech32 prefix conversion.