### PR TITLE
refactor: Fix path handling and improve directory checks

### DIFF
--- a/proto/scripts/protocgen.sh
+++ b/proto/scripts/protocgen.sh
@@ -3,15 +3,21 @@
 set -eo pipefail
 echo "Generating gogo proto code"
 cd proto
-proto_dirs=$(find ./ -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+proto_dirs=$(find ./ -type f -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
-  for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
-    if grep "option go_package" $file &> /dev/null ; then
-      buf generate --template buf.gen.gogo.yaml $file
+  for file in $(find "$dir" -maxdepth 1 -name '*.proto'); do
+    if grep "option go_package" "$file" &> /dev/null ; then
+      buf generate --template buf.gen.gogo.yaml "$file"
     fi
   done
 done
 cd ..
 # move proto files to the right places
-cp -r github.com/cosmos/gaia/* ./
-rm -rf github.com
+if [ -d "github.com/cosmos/gaia" ]; then
+    cp -r "github.com/cosmos/gaia/"* ./
+else
+    echo "Directory github.com/cosmos/gaia does not exist"
+fi
+if [ -d "github.com" ]; then
+    rm -rf github.com
+fi


### PR DESCRIPTION
Made a few quick fixes to improve stability:

1. Added quotes around variables like `$file` and `$dir` to avoid issues with spaces in paths.
2. Simplified the `find` command by removing unnecessary `-path -prune`.
3. Added checks to ensure directories exist before copying or deleting.
4. Used quotes in `cp` to handle paths with spaces properly.

Now the script should work more reliably.