### PR TITLE
fix: Add extldflags to linux builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -104,7 +104,7 @@ builds:
     ldflags:
       - -s -w
       - -linkmode=external
-      - -extldflags "-Wl,-z,muldefs -static"
+      - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
       - -X main.commit={{.Commit}}
       - -X main.date={{ .CommitDate }}
       - -X github.com/cosmos/cosmos-sdk/version.Name=gaia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Bump [ibc-apps/modules/rate-limiting](https://github.com/cosmos/ibc-apps/tree/main/modules/rate-limiting) to [v10.0.0-beta.2-bugfix.1](https://github.com/cosmos/ibc-apps/tree/modules/rate-limiting/v10.0.0-beta.2-bugfix.1) ([\#3588](https://github.com/cosmos/gaia/pull/3588))
 
 ### BUG FIXES
+- Add linker flags for noexec linux builds
+  ([\#3666](https://github.com/cosmos/gaia/pull/3666))
 - Export only validators that are participating in consensus
   ([\#3490](https://github.com/cosmos/gaia/pull/3490))
 - Fix goreleaser config to generate Linux builds again. ([\#3506](https://github.com/cosmos/gaia/pull/3506))

--- a/Makefile
+++ b/Makefile
@@ -71,15 +71,24 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
 			-X github.com/cometbft/cometbft/version.TMCoreSemVer=$(TM_VERSION)
 
+extldflags := ""
+UNAME_S = $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+  extldflags += -z noexecstack
+endif
 ifeq (cleveldb,$(findstring cleveldb,$(GAIA_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb
 endif
 ifeq ($(LINK_STATICALLY),true)
-  ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static -z noexecstack"
+  extldflags += -Wl,-z,muldefs -static -z noexecstack
+  ldflags += -linkmode=external
 endif
 ifeq (,$(findstring nostrip,$(GAIA_BUILD_OPTIONS)))
   ldflags += -w -s
 endif
+extldflags += $(EXTLDFLAGS)
+extldflags := $(strip $(extldflags))
+ldflags += -extldflags $(extldflags)
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
 			-X github.com/cometbft/cometbft/version.TMCoreSemVer=$(TM_VERSION)
 
-extldflags := ""
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
   extldflags += -z noexecstack
@@ -88,7 +87,7 @@ ifeq (,$(findstring nostrip,$(GAIA_BUILD_OPTIONS)))
 endif
 extldflags += $(EXTLDFLAGS)
 extldflags := $(strip $(extldflags))
-ldflags += -extldflags $(extldflags)
+ldflags += -extldflags "$(extldflags)"
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ ifeq (cleveldb,$(findstring cleveldb,$(GAIA_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb
 endif
 ifeq ($(LINK_STATICALLY),true)
-  ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
+  ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static -z noexecstack"
 endif
 ifeq (,$(findstring nostrip,$(GAIA_BUILD_OPTIONS)))
   ldflags += -w -s


### PR DESCRIPTION
Adds `-extldflags -z noexecstack` to linux builds via goreleaser and the Dockerfile.