### PR TITLE
Fix broken changelog link 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## 📝 Changelog
 
-Check out the [changelog](https://github.com/cosmos/gaia/blob/<v*.*.*>/CHANGELOG.md) for a list of relevant changes or [compare all changes](https://github.com/cosmos/gaia/compare/<v-last>...<v*.*.*>) from last release.
+Check out the [changelog](https://github.com/cosmos/gaia/blob/main/CHANGELOG.md) for a list of relevant changes or [compare all changes](https://github.com/cosmos/gaia/compare/<v-last>...<v*.*.*>) from last release.
 
 <!-- Add the following line for major releases -->
 Refer to the [upgrading guide](https://github.com/cosmos/gaia/blob/release/<v*.x>/UPGRADING.md) when migrating from `<v-last.x>` to `<v*.x>`.


### PR DESCRIPTION
The previous changelog link pointed to a placeholder path (<v*.*.*>), which didn't resolve correctly.
Updated it to the correct file path on the main branch:
https://github.com/cosmos/gaia/blob/main/CHANGELOG.md — making the link usable for anyone referencing the release notes.

Let me know if you'd prefer a tag-specific link instead.