### PR TITLE
fix: improve genesis account validation and fix minor typos in logs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -339,7 +339,7 @@ func NewGaiaApp(
 	app.setupUpgradeHandlers()
 	app.setupUpgradeStoreLoaders()
 
-	// At startup, after all modules have been registered, check that all prot
+	// At startup, after all modules have been registered, check that all proto
 	// annotations are correct.
 	protoFiles, err := proto.MergedRegistry()
 	if err != nil {
@@ -360,11 +360,11 @@ func NewGaiaApp(
 		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
 
 		if err := app.AppKeepers.WasmKeeper.InitializePinnedCodes(ctx); err != nil {
-			tmos.Exit(fmt.Sprintf("WasmKeeper failed initialize pinned codes %s", err))
+			tmos.Exit(fmt.Sprintf("WasmKeeper failed to initialize pinned codes %s", err))
 		}
 
 		if err := app.WasmClientKeeper.InitializePinnedCodes(ctx); err != nil {
-			panic(fmt.Sprintf("wasmlckeeper failed initialize pinned codes %s", err))
+			panic(fmt.Sprintf("wasmlckeeper failed to initialize pinned codes %s", err))
 		}
 	}
 

--- a/app/genesis_account.go
+++ b/app/genesis_account.go
@@ -32,6 +32,10 @@ func (sga SimGenesisAccount) Validate() error {
 		return errors.New("OriginalVesting amount must not be nil")
 	}
 
+	if sga.DelegatedFree == nil || sga.DelegatedVesting == nil {
+		return errors.New("DelegatedFree and DelegatedVesting must not be nil")
+	}
+
 	if !sga.OriginalVesting.IsZero() {
 		if sga.StartTime >= sga.EndTime {
 			return errors.New("vesting start-time cannot be before end-time")


### PR DESCRIPTION
1. Enhanced validation in `SimGenesisAccount.Validate()`
   - Added nil checks for `DelegatedFree` and `DelegatedVesting` fields to prevent possible runtime panics during genesis processing.
   - Ensures more robust account validation and clearer error messages for misconfigured genesis accounts.

2. Fixed minor typos in logs and comments
   - `prot annotations` ➜ corrected to `proto annotations`
   - Added missing `to` in log messages:  
     - `"WasmKeeper failed initialize pinned codes"` ➜ `"WasmKeeper failed to initialize pinned codes"`
     - `"wasmlckeeper failed initialize pinned codes"` ➜ `"wasmlckeeper failed to initialize pinned codes"`

