### PR TITLE
feat: lsm migration

### DIFF
--- a/app/upgrades/v24/constants.go
+++ b/app/upgrades/v24/constants.go
@@ -1,0 +1,23 @@
+package v24
+
+import (
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/gaia/v23/app/upgrades"
+	liquidtypes "github.com/cosmos/gaia/v23/x/liquid/types"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v24"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added: []string{
+			liquidtypes.ModuleName,
+		},
+	},
+}

--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -2,11 +2,9 @@ package v24
 
 import (
 	"context"
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
@@ -112,14 +110,15 @@ func migrateTotalLiquidStakedTokens(ctx sdk.Context, sk *stakingkeeper.Keeper, l
 
 func migrateTokenizeShareLocks(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) error {
 	tokenizeShareLocks := sk.GetAllTokenizeSharesLocks(ctx)
-	for _, lock := range tokenizeShareLocks {
-		accAddr, err := sdk.AccAddressFromBech32(lock.Address)
-		if err != nil {
-			return err
+	converted := make([]liquidtypes.TokenizeShareLock, len(tokenizeShareLocks))
+	for i, tokenizeShareLock := range tokenizeShareLocks {
+		converted[i] = liquidtypes.TokenizeShareLock{
+			Address:        tokenizeShareLock.Address,
+			Status:         tokenizeShareLock.Status,
+			CompletionTime: tokenizeShareLock.CompletionTime,
 		}
-		lsmk.AddTokenizeSharesLock(ctx, accAddr)
-		lsmk.SetTokenizeSharesUnlockTime(ctx, accAddr, lock.CompletionTime)
 	}
+	lsmk.SetTokenizeShareLocks(ctx, converted)
 
 	return nil
 }

--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -1,0 +1,125 @@
+package v24
+
+import (
+	"context"
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+
+	"github.com/cosmos/gaia/v23/app/keepers"
+	liquidkeeper "github.com/cosmos/gaia/v23/x/liquid/keeper"
+	liquidtypes "github.com/cosmos/gaia/v23/x/liquid/types"
+)
+
+// CreateUpgradeHandler returns an upgrade handler for Gaia v24.
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(c)
+		ctx.Logger().Info("Starting module migrations...")
+
+		vm, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return vm, errorsmod.Wrapf(err, "running module migrations")
+		}
+
+		err = MigrateLSMState(ctx, keepers)
+		if err != nil {
+			return vm, errorsmod.Wrapf(err, "migrating LSM state to x/liquid")
+		}
+
+		ctx.Logger().Info("Upgrade v23 complete")
+		return vm, nil
+	}
+}
+
+func MigrateLSMState(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	sk := keepers.StakingKeeper
+	lsmk := keepers.LiquidKeeper
+
+	err := migrateParams(ctx, sk, lsmk)
+	if err != nil {
+		return fmt.Errorf("error migrating params: %w", err)
+	}
+
+	err = migrateTokenizeShareRecords(ctx, sk, lsmk)
+	if err != nil {
+		return fmt.Errorf("error migrating tokenize records: %w", err)
+	}
+
+	migrateLastTokenizeShareRecordID(ctx, sk, lsmk)
+	migrateTotalLiquidStakedTokens(ctx, sk, lsmk)
+
+	err = migrateTokenizeShareLocks(ctx, sk, lsmk)
+	if err != nil {
+		return fmt.Errorf("error migrating tokenize records: %w", err)
+	}
+
+	return nil
+}
+
+func migrateParams(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) error {
+	stakingParams, err := sk.GetParams(ctx)
+	if err != nil {
+		return err
+	}
+
+	liquidParams, err := lsmk.GetParams(ctx)
+	if err != nil {
+		return err
+	}
+
+	liquidParams.GlobalLiquidStakingCap = stakingParams.GlobalLiquidStakingCap
+	liquidParams.ValidatorLiquidStakingCap = stakingParams.ValidatorLiquidStakingCap
+
+	return lsmk.SetParams(ctx, liquidParams)
+}
+
+func migrateTokenizeShareRecords(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) error {
+	tokenizeShareRecords := sk.GetAllTokenizeShareRecords(ctx)
+	for _, record := range tokenizeShareRecords {
+		lsmRecord := liquidtypes.TokenizeShareRecord{
+			Id:            record.Id,
+			Owner:         record.Owner,
+			ModuleAccount: record.ModuleAccount,
+			Validator:     record.Validator,
+		}
+		if err := lsmk.AddTokenizeShareRecord(ctx, lsmRecord); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func migrateLastTokenizeShareRecordID(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) {
+	lastTokenizeShareRecordID := sk.GetLastTokenizeShareRecordID(ctx)
+	lsmk.SetLastTokenizeShareRecordID(ctx, lastTokenizeShareRecordID)
+}
+
+func migrateTotalLiquidStakedTokens(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) {
+	totalLiquidStaked := sk.GetTotalLiquidStakedTokens(ctx)
+	lsmk.SetTotalLiquidStakedTokens(ctx, totalLiquidStaked)
+}
+
+func migrateTokenizeShareLocks(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) error {
+	tokenizeShareLocks := sk.GetAllTokenizeSharesLocks(ctx)
+	for _, lock := range tokenizeShareLocks {
+		accAddr, err := sdk.AccAddressFromBech32(lock.Address)
+		if err != nil {
+			return err
+		}
+		lsmk.AddTokenizeSharesLock(ctx, accAddr)
+		lsmk.SetTokenizeSharesUnlockTime(ctx, accAddr, lock.CompletionTime)
+	}
+
+	return nil
+}

--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -2,9 +2,11 @@ package v24
 
 import (
 	"context"
+	"fmt"
+
 	errorsmod "cosmossdk.io/errors"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
@@ -55,11 +57,7 @@ func MigrateLSMState(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 
 	migrateLastTokenizeShareRecordID(ctx, sk, lsmk)
 	migrateTotalLiquidStakedTokens(ctx, sk, lsmk)
-
-	err = migrateTokenizeShareLocks(ctx, sk, lsmk)
-	if err != nil {
-		return fmt.Errorf("error migrating tokenize records: %w", err)
-	}
+	migrateTokenizeShareLocks(ctx, sk, lsmk)
 
 	return nil
 }
@@ -108,7 +106,7 @@ func migrateTotalLiquidStakedTokens(ctx sdk.Context, sk *stakingkeeper.Keeper, l
 	lsmk.SetTotalLiquidStakedTokens(ctx, totalLiquidStaked)
 }
 
-func migrateTokenizeShareLocks(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) error {
+func migrateTokenizeShareLocks(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liquidkeeper.Keeper) {
 	tokenizeShareLocks := sk.GetAllTokenizeSharesLocks(ctx)
 	converted := make([]liquidtypes.TokenizeShareLock, len(tokenizeShareLocks))
 	for i, tokenizeShareLock := range tokenizeShareLocks {
@@ -119,6 +117,4 @@ func migrateTokenizeShareLocks(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *
 		}
 	}
 	lsmk.SetTokenizeShareLocks(ctx, converted)
-
-	return nil
 }

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -30,6 +30,8 @@ func TestMigrateLSMState(t *testing.T) {
 	addr2 := sdk.AccAddress("addr2_______________")
 
 	newContext := func(t *testing.T) (*gaia.GaiaApp, sdk.Context) {
+		t.Helper()
+
 		app := helpers.Setup(t)
 		ctx := app.NewUncachedContext(true, tmproto.Header{Time: time.Now()})
 		return app, ctx
@@ -44,6 +46,8 @@ func TestMigrateLSMState(t *testing.T) {
 	}
 
 	addValidatorAndDelegation := func(t *testing.T, app *gaia.GaiaApp, ctx sdk.Context, valAddr sdk.ValAddress, moduleAddr sdk.AccAddress) {
+		t.Helper()
+
 		val := stakingtypes.Validator{
 			OperatorAddress: valAddr.String(),
 			Tokens:          math.NewInt(1_000_000),
@@ -84,6 +88,8 @@ func TestMigrateLSMState(t *testing.T) {
 			},
 			expectError: false,
 			validate: func(t *testing.T, ctx sdk.Context, app *gaia.GaiaApp) {
+				t.Helper()
+
 				records := app.LiquidKeeper.GetAllTokenizeShareRecords(ctx)
 				require.Len(t, records, 1)
 

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -1,7 +1,6 @@
 package v24_test
 
 import (
-	"cosmossdk.io/math"
 	"fmt"
 	"testing"
 	"time"
@@ -9,6 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	"cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -1,0 +1,135 @@
+package v24_test
+
+import (
+	"cosmossdk.io/math"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/cosmos/gaia/v23/app/helpers"
+	"github.com/cosmos/gaia/v23/app/upgrades/v24"
+	"github.com/cosmos/gaia/v23/x/liquid/types"
+)
+
+var (
+	addr1 = sdk.AccAddress("addr1_______________")
+	addr2 = sdk.AccAddress("addr2_______________")
+)
+
+func TestMigrateLSMState(t *testing.T) {
+	t.Run("single tokenize share record and lock", func(t *testing.T) {
+		gaiaApp := helpers.Setup(t)
+		ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{Time: time.Now()})
+
+		// Params
+		stakingParams, err := gaiaApp.StakingKeeper.GetParams(ctx)
+		require.NoError(t, err)
+		stakingParams.GlobalLiquidStakingCap = math.LegacyNewDec(1000)
+		stakingParams.ValidatorLiquidStakingCap = math.LegacyNewDec(100)
+		require.NoError(t, gaiaApp.StakingKeeper.SetParams(ctx, stakingParams))
+
+		// Record
+		record := types.TokenizeShareRecord{
+			Id:            1,
+			Owner:         sdk.MustBech32ifyAddressBytes("cosmos", addr2),
+			ModuleAccount: "cosmos1modacct",
+			Validator:     "cosmosvaloper1xyz",
+		}
+		require.NoError(t, gaiaApp.StakingKeeper.AddTokenizeShareRecord(ctx, stakingtypes.TokenizeShareRecord(record)))
+
+		gaiaApp.StakingKeeper.SetLastTokenizeShareRecordID(ctx, 1)
+		gaiaApp.StakingKeeper.SetTotalLiquidStakedTokens(ctx, math.NewInt(12345))
+
+		// Lock
+		unlockTime := time.Now()
+		gaiaApp.StakingKeeper.AddTokenizeSharesLock(ctx, addr1)
+		gaiaApp.StakingKeeper.SetTokenizeSharesUnlockTime(ctx, addr1, unlockTime)
+
+		// Migrate
+		require.NoError(t, v24.MigrateLSMState(ctx, &gaiaApp.AppKeepers))
+
+		// Verify
+		params, err := gaiaApp.LiquidKeeper.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, stakingParams.GlobalLiquidStakingCap, params.GlobalLiquidStakingCap)
+
+		records := gaiaApp.LiquidKeeper.GetAllTokenizeShareRecords(ctx)
+		require.Len(t, records, 1)
+
+		status, unlock := gaiaApp.LiquidKeeper.GetTokenizeSharesLock(ctx, addr1)
+		require.Equal(t, types.TOKENIZE_SHARE_LOCK_STATUS_LOCK_EXPIRING, status)
+		require.Equal(t, unlockTime.Unix(), unlock.Unix())
+	})
+
+	t.Run("multiple records and locks", func(t *testing.T) {
+		gaiaApp := helpers.Setup(t)
+		ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{Time: time.Now()})
+
+		// Add multiple records
+		for i := uint64(1); i <= 3; i++ {
+			owner := sdk.MustBech32ifyAddressBytes("cosmos", sdk.AccAddress([]byte(fmt.Sprintf("owner%d_____________", i))))
+			record := stakingtypes.TokenizeShareRecord{
+				Id:            i,
+				Owner:         owner,
+				ModuleAccount: fmt.Sprintf("cosmos1modacct%d", i),
+				Validator:     fmt.Sprintf("cosmosvaloper1xyz%d", i),
+			}
+			require.NoError(t, gaiaApp.StakingKeeper.AddTokenizeShareRecord(ctx, record))
+		}
+		gaiaApp.StakingKeeper.SetLastTokenizeShareRecordID(ctx, 3)
+		gaiaApp.StakingKeeper.SetTotalLiquidStakedTokens(ctx, math.NewInt(98765))
+
+		// Locks
+		for _, addr := range []sdk.AccAddress{addr1, addr2} {
+			gaiaApp.StakingKeeper.AddTokenizeSharesLock(ctx, addr)
+			gaiaApp.StakingKeeper.SetTokenizeSharesUnlockTime(ctx, addr, time.Now())
+		}
+
+		require.NoError(t, v24.MigrateLSMState(ctx, &gaiaApp.AppKeepers))
+
+		records := gaiaApp.LiquidKeeper.GetAllTokenizeShareRecords(ctx)
+		require.Len(t, records, 3)
+
+		for _, addr := range []sdk.AccAddress{addr1, addr2} {
+			status, _ := gaiaApp.LiquidKeeper.GetTokenizeSharesLock(ctx, addr)
+			require.Equal(t, types.TOKENIZE_SHARE_LOCK_STATUS_LOCK_EXPIRING, status)
+		}
+	})
+
+	t.Run("empty state should not fail", func(t *testing.T) {
+		gaiaApp := helpers.Setup(t)
+		ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{Time: time.Now()})
+
+		require.NoError(t, v24.MigrateLSMState(ctx, &gaiaApp.AppKeepers))
+
+		records := gaiaApp.LiquidKeeper.GetAllTokenizeShareRecords(ctx)
+		require.Empty(t, records)
+	})
+
+	t.Run("double migration", func(t *testing.T) {
+		gaiaApp := helpers.Setup(t)
+		ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{Time: time.Now()})
+
+		// One record
+		record := stakingtypes.TokenizeShareRecord{
+			Id:            1,
+			Owner:         sdk.MustBech32ifyAddressBytes("cosmos", addr2),
+			ModuleAccount: "cosmos1modacct",
+			Validator:     "cosmosvaloper1xyz",
+		}
+		require.NoError(t, gaiaApp.StakingKeeper.AddTokenizeShareRecord(ctx, record))
+
+		// Run twice
+		require.NoError(t, v24.MigrateLSMState(ctx, &gaiaApp.AppKeepers))
+		require.Error(t, v24.MigrateLSMState(ctx, &gaiaApp.AppKeepers))
+
+		records := gaiaApp.LiquidKeeper.GetAllTokenizeShareRecords(ctx)
+		require.Len(t, records, 1)
+	})
+}

--- a/app/upgrades/v24/upgrades_test.go
+++ b/app/upgrades/v24/upgrades_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cosmossdk.io/math"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"

--- a/cmd/gaiad/cmd/testnet.go
+++ b/cmd/gaiad/cmd/testnet.go
@@ -316,7 +316,7 @@ func initTestnetFiles(
 			sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
 			stakingtypes.NewDescription(nodeDirName, "", "", "", ""),
 			stakingtypes.NewCommissionRates(math.LegacyOneDec(), math.LegacyOneDec(), math.LegacyOneDec()),
-			math.OneInt(),
+			// math.OneInt(),
 		)
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -275,15 +275,20 @@ require (
 )
 
 replace (
+	// Use version with lsm changes
+	cosmossdk.io/api => github.com/informalsystems/cosmos-sdk/api v0.7.5-lsm
+
 	// Use cosmos keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+
+	// Use special SDK v0.50.x release with support for both ICS and LSM
+	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.11-lsm
 
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1
-
 	// following versions might cause unexpected behavior
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
 	// Use special SDK v0.50.x release with support for both ICS and LSM
-	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250423173756-a145735af411
+	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250424171705-65ac99fcc3a9
 
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
 	// Use special SDK v0.50.x release with support for both ICS and LSM
-	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.11-lsm
+	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250423173756-a145735af411
 
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ cloud.google.com/go/webrisk v1.5.0/go.mod h1:iPG6fr52Tv7sGk0H6qUFzmL3HHZev1htXuW
 cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1Vwf+KmJENM0=
 cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
-cosmossdk.io/api v0.7.6 h1:PC20PcXy1xYKH2KU4RMurVoFjjKkCgYRbVAD4PdqUuY=
-cosmossdk.io/api v0.7.6/go.mod h1:IcxpYS5fMemZGqyYtErK7OqvdM0C8kdW3dq8Q/XIG38=
 cosmossdk.io/client/v2 v2.0.0-beta.7 h1:O0PfZL5kC3Sp54wZASLNihQ612Gd6duMp11aM9wawNg=
 cosmossdk.io/client/v2 v2.0.0-beta.7/go.mod h1:TzwwrzeK+AfSVSESVEIOYO/9xuCh1fPv0HgeocmfVnM=
 cosmossdk.io/collections v0.4.0 h1:PFmwj2W8szgpD5nOd8GWH6AbYNi1f2J6akWXJ7P5t9s=
@@ -465,8 +463,8 @@ github.com/cosmos/cosmos-db v1.1.1 h1:FezFSU37AlBC8S98NlSagL76oqBRWq/prTPvFcEJNC
 github.com/cosmos/cosmos-db v1.1.1/go.mod h1:AghjcIPqdhSLP/2Z0yha5xPH3nLnskz81pBx3tcVSAw=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.50.13 h1:xQ32hhzVy7agEe7behMdZN0ezWhPss3KoLZsF9KoBnw=
-github.com/cosmos/cosmos-sdk v0.50.13/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
+github.com/cosmos/cosmos-sdk v0.50.11-lsm h1:fExTM8+aWWgDCnU+P41yYJHQWTRBouQZJNfLbjYvk3o=
+github.com/cosmos/cosmos-sdk v0.50.11-lsm/go.mod h1:NflT1/PkUKwiAI2H6pZbn5I3bVYcY05qzk64XgZwkmw=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -937,6 +935,8 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
+github.com/informalsystems/cosmos-sdk/api v0.7.5-lsm h1:M0+CQZLf2yS41TiWaiKw8nF5vlPaFDmVfwfyMHViRZk=
+github.com/informalsystems/cosmos-sdk/api v0.7.5-lsm/go.mod h1:IcxpYS5fMemZGqyYtErK7OqvdM0C8kdW3dq8Q/XIG38=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/cosmos/cosmos-db v1.1.1 h1:FezFSU37AlBC8S98NlSagL76oqBRWq/prTPvFcEJNC
 github.com/cosmos/cosmos-db v1.1.1/go.mod h1:AghjcIPqdhSLP/2Z0yha5xPH3nLnskz81pBx3tcVSAw=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.50.11-lsm h1:fExTM8+aWWgDCnU+P41yYJHQWTRBouQZJNfLbjYvk3o=
-github.com/cosmos/cosmos-sdk v0.50.11-lsm/go.mod h1:NflT1/PkUKwiAI2H6pZbn5I3bVYcY05qzk64XgZwkmw=
+github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250423173756-a145735af411 h1:nHeTCA+nJ+wi5AHW8dZCohhuKpVKn5nQP6ye6JjapWo=
+github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250423173756-a145735af411/go.mod h1:NflT1/PkUKwiAI2H6pZbn5I3bVYcY05qzk64XgZwkmw=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/cosmos/cosmos-db v1.1.1 h1:FezFSU37AlBC8S98NlSagL76oqBRWq/prTPvFcEJNC
 github.com/cosmos/cosmos-db v1.1.1/go.mod h1:AghjcIPqdhSLP/2Z0yha5xPH3nLnskz81pBx3tcVSAw=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250423173756-a145735af411 h1:nHeTCA+nJ+wi5AHW8dZCohhuKpVKn5nQP6ye6JjapWo=
-github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250423173756-a145735af411/go.mod h1:NflT1/PkUKwiAI2H6pZbn5I3bVYcY05qzk64XgZwkmw=
+github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250424171705-65ac99fcc3a9 h1:fBaN7GsCIRNzm0jTzZpzI25mOHO58CpprhxR84ioTtU=
+github.com/cosmos/cosmos-sdk v0.50.11-lsm.0.20250424171705-65ac99fcc3a9/go.mod h1:NflT1/PkUKwiAI2H6pZbn5I3bVYcY05qzk64XgZwkmw=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=

--- a/tests/e2e/common/validator.go
+++ b/tests/e2e/common/validator.go
@@ -247,7 +247,7 @@ func (v *validator) BuildCreateValidatorMsg(amount sdk.Coin) (sdk.Msg, error) {
 		amount,
 		description,
 		commissionRates,
-		math.OneInt(),
+		// math.OneInt(),
 	)
 }
 

--- a/x/liquid/keeper/genesis.go
+++ b/x/liquid/keeper/genesis.go
@@ -33,7 +33,14 @@ func (k Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) {
 	// Set the tokenize shares locks for accounts that have disabled tokenizing shares
 	// The lock can either be in status LOCKED or LOCK_EXPIRING
 	// If it is in status LOCK_EXPIRING, the unlocking must also be queued
-	for _, tokenizeShareLock := range data.TokenizeShareLocks {
+	k.SetTotalLiquidStakedTokens(ctx, data.TotalLiquidStakedTokens)
+}
+
+func (k Keeper) SetTokenizeShareLocks(ctx sdk.Context, tokenizeShareLocks []types.TokenizeShareLock) {
+	// Set the tokenize shares locks for accounts that have disabled tokenizing shares
+	// The lock can either be in status LOCKED or LOCK_EXPIRING
+	// If it is in status LOCK_EXPIRING, the unlocking must also be queued
+	for _, tokenizeShareLock := range tokenizeShareLocks {
 		address, err := k.authKeeper.AddressCodec().StringToBytes(tokenizeShareLock.Address)
 		if err != nil {
 			panic(err)

--- a/x/liquid/keeper/genesis.go
+++ b/x/liquid/keeper/genesis.go
@@ -33,10 +33,10 @@ func (k Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) {
 	// Set the tokenize shares locks for accounts that have disabled tokenizing shares
 	// The lock can either be in status LOCKED or LOCK_EXPIRING
 	// If it is in status LOCK_EXPIRING, the unlocking must also be queued
-	k.SetTotalLiquidStakedTokens(ctx, data.TotalLiquidStakedTokens)
+	k.SetTokenizeShareLocks(ctx, data.TokenizeShareLocks)
 }
 
-func (k Keeper) SetTokenizeShareLocks(ctx sdk.Context, tokenizeShareLocks []types.TokenizeShareLock) {
+func (k Keeper) SetTokenizeShareLocks(ctx context.Context, tokenizeShareLocks []types.TokenizeShareLock) {
 	// Set the tokenize shares locks for accounts that have disabled tokenizing shares
 	// The lock can either be in status LOCKED or LOCK_EXPIRING
 	// If it is in status LOCK_EXPIRING, the unlocking must also be queued

--- a/x/liquid/keeper/hooks.go
+++ b/x/liquid/keeper/hooks.go
@@ -37,15 +37,15 @@ func (h Hooks) AfterValidatorRemoved(ctx context.Context, _ sdk.ConsAddress, val
 	return h.k.RemoveLiquidValidator(ctx, valAddr)
 }
 
-func (h Hooks) BeforeDelegationCreated(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationCreated(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationSharesModified(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) AfterDelegationModified(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
@@ -84,10 +84,14 @@ func (h Hooks) AfterValidatorBeginUnbonding(_ context.Context, _ sdk.ConsAddress
 	return nil
 }
 
-func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationRemoved(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
 func (h Hooks) AfterUnbondingInitiated(_ context.Context, _ uint64) error {
+	return nil
+}
+
+func (h Hooks) BeforeTokenizeShareRecordRemoved(_ context.Context, _ uint64) error {
 	return nil
 }

--- a/x/liquid/keeper/liquid_stake.go
+++ b/x/liquid/keeper/liquid_stake.go
@@ -172,8 +172,11 @@ func (k Keeper) DecreaseTotalLiquidStakedTokens(ctx context.Context, amount math
 // and the total liquid staked shares cannot exceed the validator bond cap
 //  1. (TotalLiquidStakedTokens / TotalStakedTokens) <= ValidatorLiquidStakingCap
 //  2. LiquidShares <= (ValidatorBondShares * ValidatorBondFactor)
-func (k Keeper) SafelyIncreaseValidatorLiquidShares(ctx context.Context, valAddress sdk.ValAddress,
-	shares math.LegacyDec, sharesAlreadyBonded bool,
+func (k Keeper) SafelyIncreaseValidatorLiquidShares(
+	ctx context.Context,
+	valAddress sdk.ValAddress,
+	shares math.LegacyDec,
+	sharesAlreadyBonded bool,
 ) (types.LiquidValidator, error) {
 	validator, err := k.GetLiquidValidator(ctx, valAddress)
 	if err != nil {


### PR DESCRIPTION
Reuse some logic from the `genesis` initialization
Go back to using SDK fork so we can get the types we need

Please go the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.