### PR TITLE
fix!: Handle wrapped message in vote antehandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 *May 5, 2025*
 
 ### STATE BREAKING
-- Handle wrapped vote messages in Antehandler ([\#3712](https://github.com/cosmos/gaia/pull/3712))
+- Handle wrapped vote messages in Antehandler ([\#3726](https://github.com/cosmos/gaia/pull/3726))
 
 ## v23.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 ### STATE BREAKING
 - Add x/liquid module ([\#3712](https://github.com/cosmos/gaia/pull/3712))
 
+## v23.3.0
+
+*May 5, 2025*
+
+### STATE BREAKING
+- Handle wrapped vote messages in Antehandler ([\#3712](https://github.com/cosmos/gaia/pull/3712))
+
 ## v23.2.0
 
 *April 28, 2025*

--- a/ante/gov_vote_ante.go
+++ b/ante/gov_vote_ante.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	minStakedTokens       = math.LegacyNewDec(1000000) // 1_000_000 uatom (or 1 atom)
-	maxDelegationsChecked = 100                        // number of delegation to check for the minStakedTokens
+	minStakedTokens        = math.LegacyNewDec(1000000) // 1_000_000 uatom (or 1 atom)
+	maxDelegationsChecked  = 100                        // number of delegation to check for the minStakedTokens
+	maxWrappedMessageDepth = 20                         // maximum depth of nested exec messages allowed
 )
 
 // SetMinStakedTokens sets the minimum amount of staked tokens required to vote
@@ -57,89 +58,86 @@ func (g GovVoteDecorator) AnteHandle(
 
 // ValidateVoteMsgs checks if a voter has enough stake to vote
 func (g GovVoteDecorator) ValidateVoteMsgs(ctx sdk.Context, msgs []sdk.Msg) error {
-	validMsg := func(m sdk.Msg) error {
-		var accAddr sdk.AccAddress
-		var err error
-
-		switch msg := m.(type) {
-		case *govv1beta1.MsgVote:
-			accAddr, err = sdk.AccAddressFromBech32(msg.Voter)
-			if err != nil {
-				return err
-			}
-		case *govv1.MsgVote:
-			accAddr, err = sdk.AccAddressFromBech32(msg.Voter)
-			if err != nil {
-				return err
-			}
-		default:
-			// not a vote message - nothing to validate
-			return nil
-		}
-
-		if minStakedTokens.IsZero() {
-			return nil
-		}
-
-		enoughStake := false
-		delegationCount := 0
-		stakedTokens := math.LegacyNewDec(0)
-		err = g.stakingKeeper.IterateDelegatorDelegations(ctx, accAddr, func(delegation stakingtypes.Delegation) bool {
-			validatorAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
-			if err != nil {
-				panic(err) // shouldn't happen
-			}
-			validator, err := g.stakingKeeper.GetValidator(ctx, validatorAddr)
-			if err == nil {
-				shares := delegation.Shares
-				tokens := validator.TokensFromSharesTruncated(shares)
-				stakedTokens = stakedTokens.Add(tokens)
-				if stakedTokens.GTE(minStakedTokens) {
-					enoughStake = true
-					return true // break the iteration
-				}
-			}
-			delegationCount++
-			// break the iteration if maxDelegationsChecked were already checked
-			return delegationCount >= maxDelegationsChecked
-		})
-		if err != nil {
+	for _, msg := range msgs {
+		if err := g.validateMsgRecursive(ctx, msg, 0); err != nil {
 			return err
 		}
-
-		if !enoughStake {
-			return errorsmod.Wrapf(gaiaerrors.ErrInsufficientStake, "insufficient stake for voting - min required %v", minStakedTokens)
-		}
-
-		return nil
 	}
+	return nil
+}
 
-	validAuthz := func(execMsg *authz.MsgExec) error {
-		for _, v := range execMsg.Msgs {
+func (g GovVoteDecorator) validateMsgRecursive(ctx sdk.Context, m sdk.Msg, iters int) error {
+	if iters >= maxWrappedMessageDepth {
+		return errorsmod.Wrap(gaiaerrors.ErrNestedMessageLimitExceeded, "too many wrapped sdk messages")
+	}
+	if msg, ok := m.(*authz.MsgExec); ok {
+		for _, v := range msg.Msgs {
 			var innerMsg sdk.Msg
 			if err := g.cdc.UnpackAny(v, &innerMsg); err != nil {
 				return errorsmod.Wrap(gaiaerrors.ErrUnauthorized, "cannot unmarshal authz exec msgs")
 			}
-			if err := validMsg(innerMsg); err != nil {
+			if err := g.validateMsgRecursive(ctx, innerMsg, iters+1); err != nil {
 				return err
 			}
 		}
+		return nil
+	}
+	return g.validMsg(ctx, m)
+}
 
+func (g GovVoteDecorator) validMsg(ctx sdk.Context, m sdk.Msg) error {
+	var accAddr sdk.AccAddress
+	var err error
+
+	switch msg := m.(type) {
+	case *govv1beta1.MsgVote:
+		accAddr, err = sdk.AccAddressFromBech32(msg.Voter)
+		if err != nil {
+			return err
+		}
+	case *govv1.MsgVote:
+		accAddr, err = sdk.AccAddressFromBech32(msg.Voter)
+		if err != nil {
+			return err
+		}
+	default:
+		// not a vote message - nothing to validate
 		return nil
 	}
 
-	for _, m := range msgs {
-		if msg, ok := m.(*authz.MsgExec); ok {
-			if err := validAuthz(msg); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// validate normal msgs
-		if err := validMsg(m); err != nil {
-			return err
-		}
+	if minStakedTokens.IsZero() {
+		return nil
 	}
+
+	enoughStake := false
+	delegationCount := 0
+	stakedTokens := math.LegacyNewDec(0)
+	err = g.stakingKeeper.IterateDelegatorDelegations(ctx, accAddr, func(delegation stakingtypes.Delegation) bool {
+		validatorAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
+		if err != nil {
+			panic(err) // shouldn't happen
+		}
+		validator, err := g.stakingKeeper.GetValidator(ctx, validatorAddr)
+		if err == nil {
+			shares := delegation.Shares
+			tokens := validator.TokensFromSharesTruncated(shares)
+			stakedTokens = stakedTokens.Add(tokens)
+			if stakedTokens.GTE(minStakedTokens) {
+				enoughStake = true
+				return true // break the iteration
+			}
+		}
+		delegationCount++
+		// break the iteration if maxDelegationsChecked were already checked
+		return delegationCount >= maxDelegationsChecked
+	})
+	if err != nil {
+		return err
+	}
+
+	if !enoughStake {
+		return errorsmod.Wrapf(gaiaerrors.ErrInsufficientStake, "insufficient stake for voting - min required %v", minStakedTokens)
+	}
+
 	return nil
 }

--- a/ante/gov_vote_ante_test.go
+++ b/ante/gov_vote_ante_test.go
@@ -256,34 +256,11 @@ func TestVoteSpamDecoratorGovV1Beta1(t *testing.T) {
 		}
 
 		// Create vote message
-		msgVote := govv1beta1.NewMsgVote(
+		msg := govv1beta1.NewMsgVote(
 			delegator,
 			0,
 			govv1beta1.OptionYes,
 		)
-
-		anyVote, err := codectypes.NewAnyWithValue(
-			msgVote,
-		)
-
-		anyExecVote, err := codectypes.NewAnyWithValue(
-			&authz.MsgExec{
-				Grantee: sdk.AccAddress{}.String(),
-				Msgs: []*codectypes.Any{
-					anyVote,
-				},
-			},
-		)
-		if err != nil {
-			panic(err)
-		}
-
-		msg := &authz.MsgExec{
-			Grantee: sdk.AccAddress{}.String(),
-			Msgs: []*codectypes.Any{
-				anyExecVote,
-			},
-		}
 
 		// Validate vote message
 		err = decorator.ValidateVoteMsgs(ctx, []sdk.Msg{msg})

--- a/ante/gov_vote_ante_test.go
+++ b/ante/gov_vote_ante_test.go
@@ -9,8 +9,10 @@ import (
 
 	"cosmossdk.io/math"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -18,6 +20,131 @@ import (
 	"github.com/cosmos/gaia/v24/ante"
 	"github.com/cosmos/gaia/v24/app/helpers"
 )
+
+// Test that the GovVoteDecorator rejects votes too deeply wrapped by MsgExec
+func TestVoteSpamDecoratorMsgExecGovV1Beta1(t *testing.T) {
+	gaiaApp := helpers.Setup(t)
+	ctx := gaiaApp.NewUncachedContext(true, tmproto.Header{})
+	decorator := ante.NewGovVoteDecorator(gaiaApp.AppCodec(), gaiaApp.StakingKeeper)
+	stakingKeeper := gaiaApp.StakingKeeper
+
+	// Get validator
+	validators, err := stakingKeeper.GetAllValidators(ctx)
+	require.NoError(t, err)
+	valAddr1, err := stakingKeeper.ValidatorAddressCodec().StringToBytes(validators[0].GetOperator())
+	require.NoError(t, err)
+	valAddr1 = sdk.ValAddress(valAddr1)
+
+	// Create one more validator
+	pk := ed25519.GenPrivKeyFromSecret([]byte{uint8(13)}).PubKey()
+	validator2, err := stakingtypes.NewValidator(
+		sdk.ValAddress(pk.Address()).String(),
+		pk,
+		stakingtypes.Description{},
+	)
+	require.NoError(t, err)
+	valAddr2, err := stakingKeeper.ValidatorAddressCodec().StringToBytes(validator2.GetOperator())
+	valAddr2 = sdk.ValAddress(valAddr2)
+	require.NoError(t, err)
+	// Make sure the validator is bonded so it's not removed on Undelegate
+	validator2.Status = stakingtypes.Bonded
+	err = stakingKeeper.SetValidator(ctx, validator2)
+	require.NoError(t, err)
+	err = stakingKeeper.SetValidatorByConsAddr(ctx, validator2)
+	require.NoError(t, err)
+	err = stakingKeeper.SetNewValidatorByPowerIndex(ctx, validator2)
+	require.NoError(t, err)
+	err = stakingKeeper.Hooks().AfterValidatorCreated(ctx, valAddr2)
+	require.NoError(t, err)
+
+	// Get delegator (this account was created during setup)
+	addr, err := gaiaApp.AccountKeeper.Accounts.Indexes.Number.MatchExact(ctx, 0)
+	require.NoError(t, err)
+	delegator, err := sdk.AccAddressFromBech32(addr.String())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		bondAmt       math.Int
+		validators    []sdk.ValAddress
+		wrappedAmount int
+		expectPass    bool
+	}{
+		{
+			name:          "Non-Wrapped vote baseline",
+			bondAmt:       math.NewInt(10000000),
+			validators:    []sdk.ValAddress{valAddr1},
+			wrappedAmount: 0,
+			expectPass:    true,
+		},
+		{
+			name:          "Wrapped vote passes",
+			bondAmt:       math.NewInt(10000000),
+			validators:    []sdk.ValAddress{valAddr1},
+			wrappedAmount: 10,
+			expectPass:    true,
+		},
+		{
+			name:          "Wrapped vote failure",
+			bondAmt:       math.NewInt(10000000),
+			validators:    []sdk.ValAddress{valAddr1},
+			wrappedAmount: 20,
+			expectPass:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		// Unbond all tokens for this delegator
+		delegations, err := stakingKeeper.GetAllDelegatorDelegations(ctx, delegator)
+		require.NoError(t, err)
+		for _, del := range delegations {
+			valAddr, err := sdk.ValAddressFromBech32(del.GetValidatorAddr())
+			require.NoError(t, err)
+			_, _, err = stakingKeeper.Undelegate(ctx, delegator, valAddr, del.GetShares())
+			require.NoError(t, err)
+		}
+
+		// Delegate tokens
+		if !tc.bondAmt.IsZero() {
+			amt := tc.bondAmt.Quo(math.NewInt(int64(len(tc.validators))))
+			for _, valAddr := range tc.validators {
+				val, err := stakingKeeper.GetValidator(ctx, valAddr)
+				require.NoError(t, err)
+				_, err = stakingKeeper.Delegate(ctx, delegator, amt, stakingtypes.Unbonded, val, true)
+				require.NoError(t, err)
+			}
+		}
+
+		// Create vote message
+		var currMsg sdk.Msg = govv1beta1.NewMsgVote(
+			delegator,
+			0,
+			govv1beta1.OptionYes,
+		)
+		// Wrap the message in MsgExec
+		for i := 0; i < tc.wrappedAmount; i++ {
+			anyMsg, err := codectypes.NewAnyWithValue(currMsg)
+			if err != nil {
+				panic(err)
+			}
+
+			currMsg = &authz.MsgExec{
+				Grantee: sdk.AccAddress{}.String(),
+				Msgs: []*codectypes.Any{
+					anyMsg,
+				},
+			}
+		}
+
+		// Validate vote message
+		err = decorator.ValidateVoteMsgs(ctx, []sdk.Msg{currMsg})
+		if tc.expectPass {
+			require.NoError(t, err, "expected %v to pass", tc.name)
+		} else {
+			require.Error(t, err, "expected %v to fail", tc.name)
+		}
+	}
+}
 
 // Test that the GovVoteDecorator rejects v1beta1 vote messages from accounts with less than 1 atom staked
 // Submitting v1beta1.VoteMsg should not be possible through the CLI, but it's still possible to craft a transaction
@@ -129,11 +256,34 @@ func TestVoteSpamDecoratorGovV1Beta1(t *testing.T) {
 		}
 
 		// Create vote message
-		msg := govv1beta1.NewMsgVote(
+		msgVote := govv1beta1.NewMsgVote(
 			delegator,
 			0,
 			govv1beta1.OptionYes,
 		)
+
+		anyVote, err := codectypes.NewAnyWithValue(
+			msgVote,
+		)
+
+		anyExecVote, err := codectypes.NewAnyWithValue(
+			&authz.MsgExec{
+				Grantee: sdk.AccAddress{}.String(),
+				Msgs: []*codectypes.Any{
+					anyVote,
+				},
+			},
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		msg := &authz.MsgExec{
+			Grantee: sdk.AccAddress{}.String(),
+			Msgs: []*codectypes.Any{
+				anyExecVote,
+			},
+		}
 
 		// Validate vote message
 		err = decorator.ValidateVoteMsgs(ctx, []sdk.Msg{msg})

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -37,4 +37,6 @@ var (
 
 	// ErrInvalidExpeditedProposal is used when an expedite proposal is submitted for an unsupported proposal type.
 	ErrInvalidExpeditedProposal = errorsmod.Register(codespace, 10, "unsupported expedited proposal type")
+
+	ErrNestedMessageLimitExceeded = errorsmod.Register(codespace, 11, "nested message limit exceeded")
 )


### PR DESCRIPTION


## Description


Adds handling to our governance vote antehandler which will validate vote messages wrapped with authz MsgExec.

This change introduces a new limit on txns which is the `maxWrappedMessageDepth`. It will return an error when validating any transaction which is wrapped in a `MsgExec` at least 20 times. I've introduced this field somewhat arbitrarily--there should not be a valid use case for wrapping a message in an authz exec this many times. If there is we should introduce that fix upstream in the SDK.

All other validations of the messages should remain the same.