### PR TITLE
chore: Update nodejs version used in docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js 🔧
         uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "18.x"
 
       # npm install npm should be removed when https://github.com/npm/cli/issues/4942 is fixed
       - name: Build 🔧


### PR DESCRIPTION
Updating the nodejs version used in the docs deploy workflow since the previous run failed
https://github.com/cosmos/gaia/actions/runs/14933150610/job/41954245132

with the error:
```
Error:  Minimum Node.js version not met :(
[INFO] You are using Node.js v16.20.2, Requirement: Node.js >=18.0.
```