### PR TITLE
docs: Fix markdown docs build

### DIFF
--- a/docs/docs/architecture/templates/adr-template.md
+++ b/docs/docs/architecture/templates/adr-template.md
@@ -2,15 +2,15 @@
 order: false
 -->
 
-# ADR {ADR-NUMBER}: {TITLE}
+# ADR {'{'}ADR-NUMBER{'}'}: {'{'}TITLE{'}'}
 
 ## Changelog
 
-- {date}: {changelog}
+- {'{'}date{'}'}: {'{'}changelog{'}'}
 
 ## Status
 
-{DRAFT | PROPOSED} Not Implemented
+{'{'}DRAFT | PROPOSED{'}'} Not Implemented
 
 > Please have a look at the [PROCESS](../adr/PROCESS#adr-status) page.
 > Use DRAFT if the ADR is in a draft stage (draft PR) or PROPOSED if it's in review.
@@ -41,18 +41,18 @@ If the proposed change will be large, please also indicate a way to do the chang
 
 ### Positive
 
-> {positive consequences}
+> {'{'}positive consequences{'}'}
 
 ### Negative
 
-> {negative consequences}
+> {'{'}negative consequences{'}'}
 
 ### Neutral
 
-> {neutral consequences}
+> {'{'}neutral consequences{'}'}
 
 ## References
 
 > Are there any relevant PR comments, issues that led up to this, or articles referenced for why we made the given design choice? If so link them here!
 
-* {reference link}
+* {'{'}reference link{'}'}

--- a/docs/docs/governance/submitting.md
+++ b/docs/docs/governance/submitting.md
@@ -42,7 +42,7 @@ See the relevant section for the type of proposal you are drafting:
 
 - [Text Proposals](./formatting.md#text)
 - [Community Pool Spend Proposals](./formatting.md#community-pool-spend)
-- [Parameter Change Proposals](./formatting.md#parameter-change)
+- [Parameter Change Proposals](./formatting.md#legacy-param-change)
 
 Once on-chain, most people will rely upon block explorers to interpret this information with a graphical user interface (GUI).
 

--- a/docs/docs/hub-tutorials/join-mainnet.md
+++ b/docs/docs/hub-tutorials/join-mainnet.md
@@ -35,7 +35,6 @@ For instructions to join as a validator, please also see the [Validator Guide](.
 
 ### Overview
 <!-- DON'T FORGET TO KEEP INDEX UP TO DATE -->
-- [Join the Cosmos Hub Mainnet](#join-the-cosmos-hub-mainnet)
   - [Release History](#release-history)
     - [Overview](#overview)
   - [Explorers](#explorers)
@@ -261,8 +260,6 @@ Make sure to consult the [hardware](#hardware) section for guidance on the best 
 Blocksync is faster than traditional consensus and syncs the chain from genesis by downloading blocks and verifying against the merkle tree of validators. For more information see [CometBFT's Blocksync Docs](https://docs.cometbft.com/v0.37/core/block-sync)
 
 When syncing via Blocksync, node operators will either need to manually upgrade the chain or set up [Cosmovisor](#cosmovisor) to upgrade automatically.
-
-For more information on performing the manual upgrades, see [Releases & Upgrades](#releases--upgrades).
 
 It is possible to sync from previous versions of the Cosmos Hub. See the matrix below for the correct `gaia` version. See the [mainnet archive](https://github.com/cosmos/mainnet) for historical genesis files.
 

--- a/docs/docs/hub-tutorials/upgrade-node.md
+++ b/docs/docs/hub-tutorials/upgrade-node.md
@@ -123,7 +123,7 @@ At this point, you might want to run a script to update the exported genesis int
 ## Reset Data
 
 :::warning
-If the version <new_version> you are upgrading to is not breaking from the previous one, you should not reset the data. If it is not breaking, you can skip to [Restart](#restart)
+If the version {'<'}new_version{'>'} you are upgrading to is not breaking from the previous one, you should not reset the data. If it is not breaking, you can skip to [Restart](#restart)
 :::
 
 :::warning

--- a/docs/docs/resources/genesis.md
+++ b/docs/docs/resources/genesis.md
@@ -331,5 +331,3 @@ A `gentx` can be added manually to the genesis file, or via the following comman
 ```bash
 gaiad collect-gentxs
 ```
-
-This command will add all the `gentxs` stored in `~/.gaia/config/gentx` to the genesis file. In order to create a genesis transaction, click [here](../validators/validator-setup.md#participate-in-genesis-as-a-validator).

--- a/docs/docs/resources/service-providers.md
+++ b/docs/docs/resources/service-providers.md
@@ -277,7 +277,7 @@ Flags:
 ## REST API
 
 The REST API documents list all the available endpoints that you can use to interact
-with your full node. Learn [how to enable the REST API](../hub-tutorials/join-mainnet.md#enable-the-rest-api) on your full node.
+with your full node. Learn [how to enable the REST API](../hub-tutorials/join-mainnet.md#rest-api) on your full node.
 
 ### Listen for Incoming Transactions
 

--- a/docs/docs/validators/validator-setup.md
+++ b/docs/docs/validators/validator-setup.md
@@ -59,7 +59,7 @@ It's possible that you won't have enough ATOM to be part of the active set of va
 
 You can edit your validator's public description. This info is to identify your validator, and will be relied on by delegators to decide which validators to stake to. Make sure to provide input for every flag below. If a flag is not included in the command the field will default to empty (`--moniker` defaults to the machine name) if the field has never been set or remain the same if it has been set in the past.
 
-The <key_name> specifies which validator you are editing. If you choose to not include some of the flags below, remember that the --from flag **must** be included to identify the validator to update.
+The {'<'}key_name{'>'} specifies which validator you are editing. If you choose to not include some of the flags below, remember that the --from flag **must** be included to identify the validator to update.
 
 The `--identity` can be used as to verify identity with systems like Keybase or UPort. When using Keybase, `--identity` should be populated with a 16-digit string that is generated with a [keybase.io](https://keybase.io) account. It's a cryptographically secure method of verifying your identity across multiple online networks. The Keybase API allows us to retrieve your Keybase avatar. This is how you can add a logo to your validator profile.
 


### PR DESCRIPTION
The docs deployment is failing after upgrading the docusaurus and nodejs versions.

These are fixes in the markdown content links and characters escaping that enable the build to complete.

```
> npm run build

> cosmos-hub-docs-site@1.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...

✔ Client
  Compiled successfully in 1.74s

✔ Server



● Client █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

✔ Server


docusaurus-lunr-search:: Building search docs and lunr index file
docusaurus-lunr-search:: Start scanning documents in 11 threads
docusaurus-lunr-search:: Indexing time: 358.387ms
docusaurus-lunr-search:: indexed 53 documents out of 53
docusaurus-lunr-search:: writing search-doc.json
docusaurus-lunr-search:: writing search-doc-1746824527673.json
docusaurus-lunr-search:: writing lunr-index.json
docusaurus-lunr-search:: writing lunr-index-1746824527673.json
docusaurus-lunr-search:: End of process
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```