### PR TITLE
Use all-caps DEPENDENCIES header in Dependabot changelog action

### DIFF
--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -16,4 +16,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: crambl/dependabot-changelog-writer@trunk # Always use the latest RELEASED version of this action
       with:
+        section-header: "DEPENDENCIES"
         changelog-entry-pattern: 'Bump [dep] from [old] to [new] ([pr-link])'


### PR DESCRIPTION
Closes #3734

Configure `section-header: "DEPENDENCIES"` in the Dependabot changelog action so entries land under our all-caps DEPENDENCIES heading.
