### PR TITLE
fix: Add 0 share liquid vals

### DIFF
--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -124,6 +124,17 @@ func migrateTokenizeShares(ctx sdk.Context, sk *stakingkeeper.Keeper, lsmk *liqu
 
 	lsmk.SetTotalLiquidStakedTokens(ctx, totalLiquidStaked)
 
+	// Also add zero-ed out liquid vals
+	allVals, err := sk.GetAllValidators(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to get all validators: %w", err)
+	}
+	for _, val := range allVals {
+		if _, ok := liquidValidators[val.OperatorAddress]; !ok {
+			liquidValidators[val.OperatorAddress] = liquidtypes.NewLiquidValidator(val.OperatorAddress)
+		}
+	}
+
 	for _, liquidVal := range liquidValidators {
 		if err := lsmk.SetLiquidValidator(ctx, liquidVal); err != nil {
 			return fmt.Errorf("error migrating liquid validator: %w", err)


### PR DESCRIPTION
Adds `0` entires for validators existing at the time of upgrade which have no tokenized shares. 

The staking hooks in the liquid module automatically initialize and clean up after validator entries as they are created/deleted, but we need the upgrade handler to fully migrate existing state, not just for validators who have tokenized shares.