### PR TITLE
chore: Fix typo in v24 upgrade log

### DIFF
--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -37,7 +37,7 @@ func CreateUpgradeHandler(
 			return vm, errorsmod.Wrapf(err, "migrating LSM state to x/liquid")
 		}
 
-		ctx.Logger().Info("Upgrade v23 complete")
+		ctx.Logger().Info("Upgrade v24 complete")
 		return vm, nil
 	}
 }


### PR DESCRIPTION
Fixes the upgrade log.