### PR TITLE
fix(x/liquid): set Params during InitGenesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - Remove expedited gov prop type restrictions ([\#3723](https://github.com/cosmos/gaia/pull/3723))
 - Add liquid validator query to x/liquid ([\#3735](https://github.com/cosmos/gaia/pull/3735))
 
+### BUG-FIXES
+- Set x/liquid params during InitGenesis ([\#3759](https://github.com/cosmos/gaia/pull/3759))
+
 ### STATE BREAKING
 - Add x/liquid module ([\#3712](https://github.com/cosmos/gaia/pull/3712))
 

--- a/x/liquid/keeper/genesis.go
+++ b/x/liquid/keeper/genesis.go
@@ -11,7 +11,11 @@ import (
 
 // InitGenesis sets liquid information for genesis
 func (k Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) {
-	//
+	// Set the x/liquid module parameters
+	if err := k.SetParams(ctx, data.Params); err != nil {
+		panic(err)
+	}
+
 	// Set the total liquid staked tokens
 	k.SetTotalLiquidStakedTokens(ctx, data.TotalLiquidStakedTokens)
 


### PR DESCRIPTION
## Description

Closes: #3757

The `InitGenesis` function did not set module parameters (`Params`), which caused the values to fall back to defaults even when custom values were provided in `genesis.json`.

This change ensures `Params` are properly initialized from the genesis state.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

