### PR TITLE
test: Add validator replace option to fork tool

### DIFF
--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -41,8 +41,8 @@ import (
 )
 
 const (
-	valVotingPower int64 = 1000000
-	valTokens int64      = 1000000000000
+	valVotingPower int64 = 1000000000
+	valTokens      int64 = 1000000000000000
 )
 
 var (
@@ -80,11 +80,14 @@ thereby removing the old validator set and introducing a new set suitable for lo
 it enables developers to configure their local environments to reflect mainnet conditions more accurately.
 
 Example:
+	# Wipes the entire validator set and replaces it with a single validator
 	simd testnet unsafe-start-local-validator --validator-operator="cosmosvaloper17fjdcqy7g80pn0seexcch5pg0dtvs45p57t97r" --validator-pubkey="SLpHEfzQHuuNO9J1BB/hXyiH6c1NmpoIVQ2pMWmyctE=" --validator-privkey="AiayvI2px5CZVl/uOGmacfFjcIBoyk3Oa2JPBO6zEcdIukcR/NAe64070nUEH+FfKIfpzU2amghVDakxabJy0Q==" --accounts-to-fund="cosmos1ju6tlfclulxumtt2kglvnxduj5d93a64r5czge,cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl" [other_server_start_flags]
+	# Replaces the specified validator with the new keys
+	simd testnet unsafe-start-local-validator --validator-operator="cosmosvaloper17fjdcqy7g80pn0seexcch5pg0dtvs45p57t97r" --validator-pubkey="SLpHEfzQHuuNO9J1BB/hXyiH6c1NmpoIVQ2pMWmyctE=" --validator-privkey="AiayvI2px5CZVl/uOGmacfFjcIBoyk3Oa2JPBO6zEcdIukcR/NAe64070nUEH+FfKIfpzU2amghVDakxabJy0Q==" --accounts-to-fund="cosmos1ju6tlfclulxumtt2kglvnxduj5d93a64r5czge,cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl" --replace-validator -- replaced-operator-address="cosmosvaloper1r5v5srda7xfth3hn2s26txvrcrntldju7lnwmv" --replaced-consensus-address="04B333F6E43751948C2D56B273DC41C3E13E5932" [other_server_start_flags]
 	`
 	cmd.Flags().String(flagValidatorOperatorAddress, "", "Validator operator address e.g. cosmosvaloper17fjdcqy7g80pn0seexcch5pg0dtvs45p57t97r")
-	cmd.Flags().String(flagValidatorPubKey, "", "Validator tendermint/PubKeyEd25519 consensus public key from the priv_validato_key.json file")
-	cmd.Flags().String(flagValidatorPrivKey, "", "Validator tendermint/PrivKeyEd25519 consensus private key from the priv_validato_key.json file")
+	cmd.Flags().String(flagValidatorPubKey, "", "Validator tendermint/PubKeyEd25519 consensus public key from the priv_validator_key.json file")
+	cmd.Flags().String(flagValidatorPrivKey, "", "Validator tendermint/PrivKeyEd25519 consensus private key from the priv_validator_key.json file")
 	cmd.Flags().String(flagAccountsToFund, "", "Comma-separated list of account addresses that will be funded for testing purposes")
 	cmd.Flags().Bool(flagReplaceValidator, false, "Replaces a specified validator with the new keys")
 	cmd.Flags().String(flagReplacedOperatorAddress, "", "Operator address of the validator to be replaced")
@@ -226,7 +229,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 		Jailed:          false,
 		Status:          stakingtypes.Bonded,
 		Tokens:          math.NewInt(valTokens),
-		DelegatorShares: math.LegacyMustNewDecFromStr(string(valTokens)),
+		DelegatorShares: math.LegacyMustNewDecFromStr(fmt.Sprintf("%d", valTokens)),
 		Description: stakingtypes.Description{
 			Moniker: "Testnet Validator",
 		},
@@ -278,7 +281,7 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 			}
 		}
 	}
-	if !foundTargetValidator && args.replaceValidator {
+	if args.replaceValidator && !foundTargetValidator {
 		return fmt.Errorf("validator with operator address %s not found", args.replacedOperatorAddress)
 	}
 

--- a/cmd/gaiad/cmd/testnet_set_local_validator.go
+++ b/cmd/gaiad/cmd/testnet_set_local_validator.go
@@ -41,7 +41,8 @@ import (
 )
 
 const (
-	valVotingPower int64 = 1000000000000000
+	valVotingPower int64 = 1000000
+	valTokens int64      = 1000000000000
 )
 
 var (
@@ -224,8 +225,8 @@ func updateApplicationState(app *gaia.GaiaApp, args valArgs) error {
 		ConsensusPubkey: pubkeyAny,
 		Jailed:          false,
 		Status:          stakingtypes.Bonded,
-		Tokens:          math.NewInt(valVotingPower),
-		DelegatorShares: math.LegacyMustNewDecFromStr("1000000000000000"),
+		Tokens:          math.NewInt(valTokens),
+		DelegatorShares: math.LegacyMustNewDecFromStr(string(valTokens)),
 		Description: stakingtypes.Description{
 			Moniker: "Testnet Validator",
 		},


### PR DESCRIPTION
## Description

Adds the following flags to the forking tool:

- `replace-validator`
- `replaced-operator-address`
- `replaced-consensus-address`

It allows the user to pick between wiping the whole validator set, or replacing a single validator with a known operator and consensus address.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

