### PR TITLE
chore: Temporarily disable linux builds in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,44 +75,44 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
       - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
       - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}
-  - id: gaiad-linux-amd64
-    main: ./cmd/gaiad
-    binary: gaiad
-    builder: go
-    gobinary: "go"
-    env:
-      - CGO_ENABLED=1
-      - CC=/opt/musl-cross/bin/x86_64-linux-musl-gcc
-      - LD=/opt/musl-cross/bin/x86_64-linux-musl-ld
-      - CGO_LDFLAGS=-L/lib
-    goos:
-      - linux
-    goarch:
-      - amd64
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    tags:
-      - muslc
-      - ledger
-    hooks:
-      pre:
-        - wget -O /lib/libwasmvm_muslc.x86_64.a https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a
-        - echo "a4a3d09b36fabb65b119d5ba23442c23694401fcbee4451fe6b7e22e325a4bac /lib/libwasmvm_muslc.x86_64.a" | sha256sum -c
-        - cp /lib/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.a
-        - curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
-        - tar xf x86_64-linux-musl-cross.tgz
-        - mv x86_64-linux-musl-cross /opt/musl-cross
-    ldflags:
-      - -s -w
-      - -linkmode=external
-      - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
-      - -X main.commit={{.Commit}}
-      - -X main.date={{ .CommitDate }}
-      - -X github.com/cosmos/cosmos-sdk/version.Name=gaia
-      - -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad
-      - -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=muslc,ledger
-      - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}
+  # - id: gaiad-linux-amd64
+  # main: ./cmd/gaiad
+  # binary: gaiad
+  # builder: go
+  # gobinary: "go"
+  # env:
+  # - CGO_ENABLED=1
+  # - CC=/opt/musl-cross/bin/x86_64-linux-musl-gcc
+  # - LD=/opt/musl-cross/bin/x86_64-linux-musl-ld
+  # - CGO_LDFLAGS=-L/lib
+  # goos:
+  # - linux
+  # goarch:
+  # - amd64
+  # mod_timestamp: "{{ .CommitTimestamp }}"
+  # tags:
+  # - muslc
+  # - ledger
+  # hooks:
+  # pre:
+  # - wget -O /lib/libwasmvm_muslc.x86_64.a https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a
+  # - echo "a4a3d09b36fabb65b119d5ba23442c23694401fcbee4451fe6b7e22e325a4bac /lib/libwasmvm_muslc.x86_64.a" | sha256sum -c
+  # - cp /lib/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.a
+  # - curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
+  # - tar xf x86_64-linux-musl-cross.tgz
+  # - mv x86_64-linux-musl-cross /opt/musl-cross
+  # ldflags:
+  # - -s -w
+  # - -linkmode=external
+  # - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
+  # - -X main.commit={{.Commit}}
+  # - -X main.date={{ .CommitDate }}
+  # - -X github.com/cosmos/cosmos-sdk/version.Name=gaia
+  # - -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad
+  # - -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }}
+  # - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+  # - -X github.com/cosmos/cosmos-sdk/version.BuildTags=muslc,ledger
+  # - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}
 
 universal_binaries:
   - id: gaiad-darwin-universal
@@ -120,10 +120,10 @@ universal_binaries:
       - gaiad-darwin-arm64
       - gaiad-darwin-amd64
     replace: false
-  - id: gaiad-linux-universal
-    ids:
-      - gaiad-linux-amd64
-    replace: false
+  # - id: gaiad-linux-universal
+  # ids:
+  # - gaiad-linux-amd64
+  # replace: false
 
 archives:
   # disables archiving; to enable use commented lines below
@@ -143,7 +143,7 @@ archives:
     builds:
       - gaiad-darwin-arm64
       - gaiad-darwin-amd64
-      - gaiad-linux-amd64
+      # - gaiad-linux-amd64
     wrap_in_directory: false
     files:
       - none*


### PR DESCRIPTION
The musl.cc download ban from GH actions breaks the linxu build so for now we'll disable it and revert to the previous method in which linux builds are not done via GH actions and are uploaded to the release separately.