### PR TITLE
docs: update broken link

### DIFF
--- a/docs/docs/governance/submitting.md
+++ b/docs/docs/governance/submitting.md
@@ -249,7 +249,7 @@ The amount per deposit is equal to `min_deposit * min_deposit_ratio`. Only `uato
 ### Submitting your proposal to the testnet
 Submitting to the testnet is identical to mainnet submissions aside from a few changes:
 1. The chain-id is `theta-testnet-001`.
-2. The list of usable endpoints can be found [here](https://github.com/cosmos/testnets/tree/master/public#readme).
+2. The list of usable endpoints can be found [here](https://github.com/cosmos/testnets/blob/master/README.md).
 3. You will need testnet tokens, not ATOM. There is a faucet available in the Developer [Discord](https://discord.com/invite/cosmosnetwork).
 
 You may want to submit your proposal to the testnet chain before the mainnet for a number of reasons:


### PR DESCRIPTION
### Documentation Update

#### What has changed
- Updated the link for the list of usable endpoints in `docs/docs/governance/submitting.md` to point directly to the correct `README.md` file.

#### Why is this change necessary
- The previous link pointed to a directory section, which could be confusing. The new link points directly to the relevant `README.md` file, making it easier for users to find the information they need.

#### Additional notes
- No changes to production code.
- Only documentation has been updated for clarity and accuracy.
- before:
![before](https://github.com/user-attachments/assets/7aa8d71f-71c7-42db-ad2c-329410dcaf36)
- after
![after](https://github.com/user-attachments/assets/d09affa2-3a2e-4472-b727-3e2cd4033c8b)
