### PR TITLE
chore: remove the use of `simapp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### STATE BREAKING
 - Bump [cosmos-sdk](https://github.com/cosmos/cosmos-sdk) to [v0.53.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.0) (#3773)
+- 
+### BUG-FIXES
+- Fix the `testnet` command to use the proper gaia binary ([\#3783](https://github.com/cosmos/gaia/pull/3783))
 
 ## v24.0.0
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package gaia
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -438,6 +439,11 @@ func (app *GaiaApp) LegacyAmino() *codec.LegacyAmino {
 // for modules to register their own custom testing types.
 func (app *GaiaApp) AppCodec() codec.Codec {
 	return app.appCodec
+}
+
+// DefaultGenesis returns a default genesis from the registered AppModuleBasic's.
+func (a *GaiaApp) DefaultGenesis() map[string]json.RawMessage {
+	return a.ModuleBasics.DefaultGenesis(a.appCodec)
 }
 
 // InterfaceRegistry returns Gaia's InterfaceRegistry

--- a/app/app.go
+++ b/app/app.go
@@ -442,8 +442,8 @@ func (app *GaiaApp) AppCodec() codec.Codec {
 }
 
 // DefaultGenesis returns a default genesis from the registered AppModuleBasic's.
-func (a *GaiaApp) DefaultGenesis() map[string]json.RawMessage {
-	return a.ModuleBasics.DefaultGenesis(a.appCodec)
+func (app *GaiaApp) DefaultGenesis() map[string]json.RawMessage {
+	return app.ModuleBasics.DefaultGenesis(app.appCodec)
 }
 
 // InterfaceRegistry returns Gaia's InterfaceRegistry

--- a/cmd/gaiad/cmd/testnet.go
+++ b/cmd/gaiad/cmd/testnet.go
@@ -2,14 +2,8 @@ package cmd
 
 import (
 	"bufio"
-	"cosmossdk.io/log"
 	"encoding/json"
 	"fmt"
-	dbm "github.com/cosmos/cosmos-db"
-	bam "github.com/cosmos/cosmos-sdk/baseapp"
-	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	gaia "github.com/cosmos/gaia/v25/app"
 	"math/rand"
 	"net"
 	"os"
@@ -22,9 +16,13 @@ import (
 	"github.com/cometbft/cometbft/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
 
+	dbm "github.com/cosmos/cosmos-db"
+
+	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 
+	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -34,17 +32,20 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/server"
 	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/testutil"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-
 	"github.com/cosmos/cosmos-sdk/testutil/network"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	gaia "github.com/cosmos/gaia/v25/app"
 )
 
 var (

--- a/docs/docs/resources/service-providers.md
+++ b/docs/docs/resources/service-providers.md
@@ -87,7 +87,7 @@ Available Commands:
   start               Run the full node
   status              Query remote node for status
   tendermint          Tendermint subcommands
-  testnet             Initialize files for a simapp testnet
+  testnet             Initialize files for a gaia testnet
   tx                  Transactions subcommands
   unsafe-reset-all    Resets the blockchain database, removes address book files, and resets data/priv_validator_state.json to the genesis state
   validate-genesis    validates the genesis file at the default location or at the location passed as an arg

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	cosmossdk.io/errors v1.0.2
 	cosmossdk.io/log v1.6.0
 	cosmossdk.io/math v1.5.3
-	cosmossdk.io/simapp v0.0.0-20240118210941-3897926e722e
 	cosmossdk.io/store v1.1.2
 	cosmossdk.io/tools/confix v0.1.2
 	cosmossdk.io/tools/rosetta v0.2.1-0.20230613133644-0a778132a60f
@@ -23,7 +22,6 @@ require (
 	github.com/CosmWasm/wasmvm/v2 v2.2.3
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cometbft/cometbft-db v1.0.4
-	github.com/cometbft/cometbft/api v1.0.0
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.53.0
@@ -74,8 +72,6 @@ require (
 	cloud.google.com/go/storage v1.49.0 // indirect
 	cosmossdk.io/collections v1.2.1 // indirect
 	cosmossdk.io/depinject v1.2.0 // indirect
-	cosmossdk.io/x/circuit v0.2.0-rc.2 // indirect
-	cosmossdk.io/x/nft v0.2.0-rc.2 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,6 @@ cosmossdk.io/math v1.5.3 h1:WH6tu6Z3AUCeHbeOSHg2mt9rnoiUWVWaQ2t6Gkll96U=
 cosmossdk.io/math v1.5.3/go.mod h1:uqcZv7vexnhMFJF+6zh9EWdm/+Ylyln34IvPnBauPCQ=
 cosmossdk.io/schema v1.1.0 h1:mmpuz3dzouCoyjjcMcA/xHBEmMChN+EHh8EHxHRHhzE=
 cosmossdk.io/schema v1.1.0/go.mod h1:Gb7pqO+tpR+jLW5qDcNOSv0KtppYs7881kfzakguhhI=
-cosmossdk.io/simapp v0.0.0-20240118210941-3897926e722e h1:prrEM8wTWf6Rv0XchutuUtWfWlQHG4G3OylkTYgPlNk=
-cosmossdk.io/simapp v0.0.0-20240118210941-3897926e722e/go.mod h1:MoWto/xnPVt23TgkMEp5Rssw9Z7sV7VUQb8j5/y+fXY=
 cosmossdk.io/store v1.1.2 h1:3HOZG8+CuThREKv6cn3WSohAc6yccxO3hLzwK6rBC7o=
 cosmossdk.io/store v1.1.2/go.mod h1:60rAGzTHevGm592kFhiUVkNC9w7gooSEn5iUBPzHQ6A=
 cosmossdk.io/tools/confix v0.1.2 h1:2hoM1oFCNisd0ltSAAZw2i4ponARPmlhuNu3yy0VwI4=
@@ -650,8 +648,6 @@ cosmossdk.io/x/evidence v0.2.0-rc.2 h1:cLTCebjHTye/QoehLM8WJG4xZTFE6ET0WRY108aF/
 cosmossdk.io/x/evidence v0.2.0-rc.2/go.mod h1:FH9n6k1oCDoVk4hSd1JOiVpKO3HrFsBAL6kzfrVqagc=
 cosmossdk.io/x/feegrant v0.2.0-rc.2 h1:yA7a+wF0ax0p5d0L19KYAwaLBLawtc5woZgF0R2zzcA=
 cosmossdk.io/x/feegrant v0.2.0-rc.2/go.mod h1:Z1daRnKKiqdJqwc5+Iq8jrI2tJn2c0IKT3PwPmGpPdY=
-cosmossdk.io/x/nft v0.2.0-rc.2 h1:YrxiSienta4SLQOq8TBj1o8nvUDsZAfO2ZLMjLnVIgg=
-cosmossdk.io/x/nft v0.2.0-rc.2/go.mod h1:8bASPHFv8KOpu3pCUriZZD2LYfEcelzJGeI9mnjNS8c=
 cosmossdk.io/x/tx v0.14.0 h1:hB3O25kIcyDW/7kMTLMaO8Ripj3yqs5imceVd6c/heA=
 cosmossdk.io/x/tx v0.14.0/go.mod h1:Tn30rSRA1PRfdGB3Yz55W4Sn6EIutr9xtMKSHij+9PM=
 cosmossdk.io/x/upgrade v0.2.0-rc.2 h1:JYxl0qAEaIPG/bYfuNkJVd9blAgr2fPaCxquf1S6AXI=
@@ -880,8 +876,6 @@ github.com/cometbft/cometbft v0.38.17 h1:FkrQNbAjiFqXydeAO81FUzriL4Bz0abYxN/eOHr
 github.com/cometbft/cometbft v0.38.17/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
 github.com/cometbft/cometbft-db v1.0.4 h1:cezb8yx/ZWcF124wqUtAFjAuDksS1y1yXedvtprUFxs=
 github.com/cometbft/cometbft-db v1.0.4/go.mod h1:M+BtHAGU2XLrpUxo3Nn1nOCcnVCiLM9yx5OuT0u5SCA=
-github.com/cometbft/cometbft/api v1.0.0 h1:gGBwvsJi/gnHJEtwYfjPIGs2AKg/Vfa1ZuKCPD1/Ko4=
-github.com/cometbft/cometbft/api v1.0.0/go.mod h1:EkQiqVSu/p2ebrZEnB2z6Re7r8XNe//M7ylR0qEwWm0=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
 github.com/consensys/bavard v0.1.8-0.20210915155054-088da2f7f54a/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/bavard v0.1.22 h1:Uw2CGvbXSZWhqK59X0VG/zOjpTFuOMcPLStrp1ihI0A=
@@ -929,8 +923,6 @@ github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5Rtn
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/interchain-security/v7 v7.0.0-20250408210344-06e0dc6bf6d6 h1:SzJ/+uqrTsJmI+f/GqPdC4lGxgDQKYvtRCMXFdJljNM=
 github.com/cosmos/interchain-security/v7 v7.0.0-20250408210344-06e0dc6bf6d6/go.mod h1:W7JHsNaZ5XoH88cKT+wuCRsXkx/Fcn2kEwzpeGdJBxI=
-github.com/cosmos/interchain-security/v7 v7.0.1 h1:jg2pMbchCBN5LRDDgd9l86fcvw1v8dezGAxazhI0gtQ=
-github.com/cosmos/interchain-security/v7 v7.0.1/go.mod h1:pcb0SYZVxy1LuY4UK9ceIdQ+kjnosa9tzE3tcCWdIZw=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/cosmos/ledger-cosmos-go v0.14.0 h1:WfCHricT3rPbkPSVKRH+L4fQGKYHuGOK9Edpel8TYpE=


### PR DESCRIPTION
Right now gaiad depends on `cosmossdk.io/simapp` for its testnet initializer.  This is because it was actually spinning up a testnet of `simapp` instead of `gaiad` 

This PR fixes the error and removes the unnecessary import.