### PR TITLE
chore: Specify release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      packages: write
+      contents: write
     runs-on: Gaia-Runner-medium
     steps:
       - name: Checkout


### PR DESCRIPTION
Updated org-wide permissions has broken the release workflow.
https://github.com/cosmos/gaia/actions/runs/15784364837/job/44497388864

This should enable the workflow to publish a release.