### PR TITLE
fix: ensure default telemetry is used when no config is present

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -187,14 +187,7 @@ func NewGaiaApp(
 		logger.Debug("successfully determined if this node is a validator", "moniker", vi.Moniker)
 	}
 
-	otelConfig := gaiatelemetry.OtelConfig{
-		Disable:                 cast.ToBool(appOpts.Get("opentelemetry.disable")),
-		CollectorEndpoint:       cast.ToString(appOpts.Get("opentelemetry.collector-endpoint")),
-		CollectorMetricsURLPath: cast.ToString(appOpts.Get("opentelemetry.collector-metrics-url-path")),
-		User:                    cast.ToString(appOpts.Get("opentelemetry.user")),
-		Token:                   cast.ToString(appOpts.Get("opentelemetry.token")),
-		PushInterval:            cast.ToDuration(appOpts.Get("opentelemetry.push-interval")),
-	}
+	otelConfig := getOtelConfig(appOpts)
 	app.otelClient = gaiatelemetry.NewOtelClient(otelConfig, vi)
 
 	moduleAccountAddresses := app.ModuleAccountAddrs()
@@ -460,6 +453,25 @@ func (app *GaiaApp) BlockedModuleAccountAddrs(modAccAddrs map[string]bool) map[s
 	delete(modAccAddrs, authtypes.NewModuleAddress(providertypes.ConsumerRewardsPool).String())
 
 	return modAccAddrs
+}
+
+func getOtelConfig(appOpts servertypes.AppOptions) gaiatelemetry.OtelConfig {
+	// if appOpts.Get yields nil, this value was not set.
+	// since the user isn't making any intent to disable here, we will use the DefaultOtelConfig.
+	disableRaw := appOpts.Get("opentelemetry.disable")
+	if disableRaw == nil {
+		return gaiatelemetry.DefaultOtelConfig
+	}
+	// if disableRaw wasn't nil, the user is making the intent to use their config. so we will use their values.
+	otelConfig := gaiatelemetry.OtelConfig{
+		Disable:                 cast.ToBool(appOpts.Get("opentelemetry.disable")),
+		CollectorEndpoint:       cast.ToString(appOpts.Get("opentelemetry.collector-endpoint")),
+		CollectorMetricsURLPath: cast.ToString(appOpts.Get("opentelemetry.collector-metrics-url-path")),
+		User:                    cast.ToString(appOpts.Get("opentelemetry.user")),
+		Token:                   cast.ToString(appOpts.Get("opentelemetry.token")),
+		PushInterval:            cast.ToDuration(appOpts.Get("opentelemetry.push-interval")),
+	}
+	return otelConfig
 }
 
 // LegacyAmino returns GaiaApp's amino codec.


### PR DESCRIPTION
if you used a binary to call `init` for your node _before_ the open telemetry work was included, calling `gaiad start` with the new binary won't actually update your configs to use telemetry. the application would default to empty values, and telemetry would not start.

the fix here is to detect when there is no intent, and fill in the config accordingly.