### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/docs/hub-tutorials/join-testnet.md
+++ b/docs/docs/hub-tutorials/join-testnet.md
@@ -6,7 +6,7 @@ order: 3
 Visit the [testnets repo](https://github.com/cosmos/testnets) for the most up-to-date information on the currently available public testnets:
 
 * Interchain Security (ICS) Testnet: [`provider`](https://github.com/cosmos/testnets/blob/master/interchain-security/provider/README.md)
-* Release Testnet: [`theta-testnet-001`](https://github.com/cosmos/testnets/blob/master/release/README.md)
+* Release Testnet: [`theta-testnet-001`](https://github.com/cosmos/testnets/blob/master/legacy/theta-testnet-001/README.md)
 
 ## How to Join
 
@@ -14,7 +14,7 @@ You can set up a testnet node with a single command using one of the options bel
 
 * Run a shell script from the testnets repo
   * [ICS Testnet](https://github.com/cosmos/testnets/tree/master/interchain-security/provider#bash-script)
-  * [Release testnet](https://github.com/cosmos/testnets/blob/master/release/README.md#bash-script)
+  * [Release testnet](https://github.com/cosmos/testnets/blob/master/legacy/theta-testnet-001/README.md#bash-script)
 * Run an Ansible playbook from the [cosmos-ansible](https://github.com/hyphacoop/cosmos-ansible) repo
   * [ICS Testnet](https://github.com/hyphacoop/cosmos-ansible/blob/main/examples/README.md#provider-chain)
   * [Release Testnet](https://github.com/hyphacoop/cosmos-ansible/blob/main/examples/README.md#join-the-cosmos-hub-release-testnet)


### PR DESCRIPTION
## Summary

This PR fixes broken links in the `join-testnet.md` documentation related to the release testnet.

## What Changed

- Updated outdated URLs pointing to `release/README.md` to the correct legacy directory:  
  from  
  `https://github.com/cosmos/testnets/blob/master/release/README.md`  
  to  
  `https://github.com/cosmos/testnets/blob/master/legacy/theta-testnet-001/README.md`

- Also fixed the corresponding link in the bash script reference.

## Reason

The directory structure for testnets was changed in [#652](https://github.com/cosmos/testnets/pull/652). This PR updates the docs to reflect that change and prevent 404 errors.

## Additional Context

- File updated: `docs/docs/hub-tutorials/join-testnet.md`
- Related issue: broken markdown links to the testnet guide and bash script.
- before:
![image](https://github.com/user-attachments/assets/fdb16925-b5e4-4f6a-a8f6-4ce980feec3c)

- after:
![image](https://github.com/user-attachments/assets/1fc8ec82-e2f7-41d4-95fe-6892fccf96f9)


