### PR TITLE
fix: dead links in documentation

### DIFF
--- a/docs/docs/architecture/adr/adr-001-interchain-accounts.md
+++ b/docs/docs/architecture/adr/adr-001-interchain-accounts.md
@@ -86,7 +86,7 @@ There are future releases of Interchain Accounts which are expected to be backwa
 
 ## Support
 
-[Documentation](https://ibc.cosmos.network/main/apps/interchain-accounts/overview.html)
+[Documentation](https://ibc.cosmos.network/v8/apps/interchain-accounts/overview)
 
 ## Additional Research & References
 

--- a/docs/docs/modules/README.md
+++ b/docs/docs/modules/README.md
@@ -28,7 +28,7 @@ links for each one.
 
 ## ibc-go
 
-- [transfer](https://ibc.cosmos.network/main/apps/transfer/overview)
+- [transfer](https://ibc.cosmos.network/v8/apps/transfer/overview)
 - [interchain accounts - host](https://ibc.cosmos.network/v8/apps/interchain-accounts/client#host)
 - [interchain accounts - controller](https://ibc.cosmos.network/v8/apps/interchain-accounts/client#controller)
 - [interchain-security/provider](https://github.com/cosmos/interchain-security/tree/main/x/ccv/provider)


### PR DESCRIPTION


---

**Description:**  
This PR fixes several dead (404) links in the documentation:

- Updated IBC Interchain Accounts and Transfer links to the latest working URLs.


---