### PR TITLE
ci: Fix upgrade setup for nightly interchaintest runs.

### DIFF
--- a/tests/interchain/chainsuite/suite.go
+++ b/tests/interchain/chainsuite/suite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/mod/semver"
 )
 
 type Suite struct {
@@ -59,7 +58,7 @@ func (s *Suite) GetContext() context.Context {
 
 func (s *Suite) UpgradeChain() {
 	GetLogger(s.GetContext()).Sugar().Infof("Upgrade %s from %s to %s", s.Env.UpgradeName, s.Env.OldGaiaImageVersion, s.Env.NewGaiaImageVersion)
-	if s.Env.UpgradeName == semver.Major(s.Env.OldGaiaImageVersion) {
+	if s.Env.UpgradeName == s.Env.OldGaiaImageVersion {
 		// Not an on-chain upgrade, just replace the image.
 		s.Require().NoError(s.Chain.ReplaceImagesAndRestart(s.GetContext(), s.Env.NewGaiaImageVersion))
 	} else {


### PR DESCRIPTION
## Description

We need to account for upgrade names now being the full version name, as well as provide a real upgrade name when running a nightly build. From now, nightly builds will use either the latest released version as their upgrade name--i.e. assuming that `main` is just building on top of that release--or will use vNext.0.0 if main has been updated to be a new major version.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

