### PR TITLE
ci: Update version regex for interchaintest

### DIFF
--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -47,6 +47,7 @@ jobs:
 
           validate_or_fail() {
             local val="${1:-}"
+            echo "Validating version value: '$val'"
             [[ -n "$val" ]] || return 1
             [[ "$val" =~ $VERSION_RE ]] || return 1
             return 0

--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION_RE='^v?[0-9]+(?:\.[0-9]+){0,2}(?:-[A-Za-z0-9._-]+)?$'
+          VERSION_RE='^v?[0-9]+(\.[0-9]+){0,2}(-[A-Za-z0-9._-]+)?$'
 
           fail_invalid() {
             echo "ERROR: Invalid version value: '$1'" >&2

--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -47,7 +47,6 @@ jobs:
 
           validate_or_fail() {
             local val="${1:-}"
-            echo "Validating version value: '$val'"
             [[ -n "$val" ]] || return 1
             [[ "$val" =~ $VERSION_RE ]] || return 1
             return 0
@@ -70,9 +69,6 @@ jobs:
             echo "Not a repo dispatch event"
             ref="${RAW_REF_NAME:-}"
             tover="${RAW_TO_VERSION:-}"
-
-            echo "ref: $ref"
-            echo "tover: $tover"
 
             if [[ -n "$tover" ]]; then
               validate_or_fail "$tover" || fail_invalid "$tover"

--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -66,8 +66,12 @@ jobs:
               echo "tag_name=${ref}" >> "$GITHUB_OUTPUT"
             fi
           else
+            echo "Not a repo dispatch event"
             ref="${RAW_REF_NAME:-}"
             tover="${RAW_TO_VERSION:-}"
+
+            echo "ref: $ref"
+            echo "tover: $tover"
 
             if [[ -n "$tover" ]]; then
               validate_or_fail "$tover" || fail_invalid "$tover"

--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -66,7 +66,6 @@ jobs:
               echo "tag_name=${ref}" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "Not a repo dispatch event"
             ref="${RAW_REF_NAME:-}"
             tover="${RAW_TO_VERSION:-}"
 


### PR DESCRIPTION
## Description

Change the regular expression that checks the versions to test against to avoid premature failures on Interchain Test runs.

Here is a passing workflow run:
https://github.com/hyphacoop/gaia/actions/runs/18386659241

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

