### PR TITLE
ci: Allow nightly builds in Interchain Test

### DIFF
--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -41,13 +41,15 @@ jobs:
 
           fail_invalid() {
             echo "ERROR: Invalid version value: '$1'" >&2
-            echo "Allowed format: MAJOR[.MINOR[.PATCH]] with optional leading 'v' and optional -prerelease (alnum . _ -)." >&2
+            echo "Allowed format: MAJOR[.MINOR[.PATCH]] with optional leading 'v' and optional -prerelease (alnum . _ -), or 'nightly'." >&2
             exit 1
           }
 
           validate_or_fail() {
             local val="${1:-}"
             [[ -n "$val" ]] || return 1
+            # Allow "nightly" as a special case
+            [[ "$val" == "nightly" ]] && return 0
             [[ "$val" =~ $VERSION_RE ]] || return 1
             return 0
           }


### PR DESCRIPTION
## Description

Update the version regex to allow nightly builds to be tested in the Interchain Test workflow.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

