### PR TITLE
ci: give interchain-test status permission

### DIFF
--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   prepare-matrix:


### PR DESCRIPTION
Please go the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.