### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - uses: actions/setup-go@v5
       with:
         go-version: "1.24"

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write # needed for pushing changes
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: crambl/dependabot-changelog-writer@trunk # Always use the latest RELEASED version of this action
       with:
         changelog-entry-pattern: 'Bump [dep] from [old] to [new] ([pr-link])'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get new commits for nightly build
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV

--- a/.github/workflows/interchain-test.yml
+++ b/.github/workflows/interchain-test.yml
@@ -74,7 +74,7 @@ jobs:
           fi
 
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.get-metadata.outputs.ref_name }}
 
@@ -128,7 +128,7 @@ jobs:
       max-parallel: 10
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare-matrix.outputs.ref_name }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: golangci-lint
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"

--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -7,7 +7,7 @@ jobs:
   markdown-link-check:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
         with:
           folder-path: "docs"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -17,7 +17,7 @@ jobs:
      runs-on: depot-ubuntu-22.04-4
     if: "!contains(github.event.head_commit.message, 'skip-sims')"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: |
           make build
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     needs: [build, install-runsim]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4.2.0
         with:
           path: ~/go/bin
@@ -62,7 +62,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     needs: newbuild
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: Gaia-Runner-medium
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: git fetch --force --tags

--- a/.github/workflows/sim-label.yml
+++ b/.github/workflows/sim-label.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     needs: newbuild
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
@@ -37,7 +37,7 @@ jobs:
     needs: build
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
@@ -61,7 +61,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     needs: build
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         with:
           path: ~/go/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   tests:
     runs-on: depot-ubuntu-22.04-4
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
         with:
@@ -86,7 +86,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     needs: [tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
         with:
@@ -105,7 +105,7 @@ jobs:
     runs-on: Gaia-Runner-medium
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
@@ -137,7 +137,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: technote-space/get-diff-action@v6.1.2


### PR DESCRIPTION
Bumps `actions/checkout` from v5 to v6. Workflow-only change, no impact on functionality.

https://github.com/actions/checkout/releases/tag/v6.0.0