### PR TITLE
ci: Add OPEN state channel requirement to interchaintest

### DIFF
--- a/tests/interchain/chainsuite/relayer.go
+++ b/tests/interchain/chainsuite/relayer.go
@@ -22,7 +22,7 @@ func NewRelayer(ctx context.Context, testName interchaintest.TestName) (*Relayer
 	rly := interchaintest.NewBuiltinRelayerFactory(
 		ibc.Hermes,
 		GetLogger(ctx),
-		relayer.CustomDockerImage("ghcr.io/informalsystems/hermes", "1.12.0", "2000:2000"),
+		relayer.CustomDockerImage("ghcr.io/informalsystems/hermes", "1.13.1", "2000:2000"),
 	).Build(testName, dockerClient, dockerNetwork)
 	return &Relayer{Relayer: rly}, nil
 }
@@ -183,10 +183,11 @@ func (r *Relayer) ConnectProviderConsumer(ctx context.Context, provider *Chain, 
 	for tCtx.Err() == nil {
 		var ch *ibc.ChannelOutput
 		ch, err = r.GetTransferChannel(ctx, provider, consumer)
-		if err == nil && ch != nil {
-			break
-		} else if err == nil {
-			err = fmt.Errorf("channel not found")
+		if err == nil {
+			if ch.State == "STATE_OPEN" {
+				break
+			}
+			err = fmt.Errorf("channel found but not open yet (state: %s)", ch.State)
 		}
 		time.Sleep(CommitTimeout)
 	}

--- a/tests/interchain/consumer_chain/consumer_modification_test.go
+++ b/tests/interchain/consumer_chain/consumer_modification_test.go
@@ -361,6 +361,9 @@ func (s *ConsumerModificationSuite) TestLaunchWithAllowListThenModify() {
 	_, err = s.Chain.Validators[3].ExecTx(s.GetContext(), s.Chain.ValidatorWallets[3].Moniker,
 		"provider", "opt-in", consumerID)
 	s.Require().NoError(err)
+
+	s.Require().NoError(s.Chain.CheckCCV(s.GetContext(), consumer, s.Relayer, 1_000_000, 0, 1))
+
 	validators, err = consumer.QueryJSON(s.GetContext(), "validators", "tendermint-validator-set")
 	s.Require().NoError(err)
 	s.Require().Equal(4, len(validators.Array()))


### PR DESCRIPTION
## Description

* The Interchaintest workflow includes a check to ensure a transfer channel is present, but it may indicate that the channel is ready while it is still in the `STATE_TRYOPEN` state. The check must wait for the channel to reach the `STATE_OPEN` state now.
* Bumps Hermes from v1.12.0 to v1.13.1.
* Adds a delegation transaction to trigger a validator set change packet before checking the consumer chain validator set.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

