### PR TITLE
docs: Add v25.3.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@
 
 ### FEATURES
 
+### DEPENDENCIES
+- Bump [github.com/go-viper/mapstructure/v2](https://github.com/go-viper/mapstructure) from 2.2.1 to 2.3.0 ([#3813](https://github.com/cosmos/gaia/pull/3813))
+- Bump [github.com/cosmos/gogoproto](https://github.com/cosmos/gogoproto) from 1.7.0 to 1.7.2 ([#3916](https://github.com/cosmos/gaia/pull/3916))
+
+## v25.3.0
+
+*December 19, 2025*
 
 ### DEPENDENCIES
 - Bump [go.opentelemetry.io/otel/sdk/metric](https://github.com/open-telemetry/opentelemetry-go) from 1.36.0 to 1.37.0 ([#3820](https://github.com/cosmos/gaia/pull/3820))
-- Bump [github.com/go-viper/mapstructure/v2](https://github.com/go-viper/mapstructure) from 2.2.1 to 2.3.0 ([#3813](https://github.com/cosmos/gaia/pull/3813))
-- Bump [github.com/CosmWasm/wasmd](https://github.com/CosmWasm/wasmd) from v0.60.1 to v0.60.2 ([#3888](https://github.com/cosmos/gaia/pull/3888))
-- Bump [github.com/cosmos/gogoproto](https://github.com/cosmos/gogoproto) from 1.7.0 to 1.7.2 ([#3916](https://github.com/cosmos/gaia/pull/3916))
-- Bump [cometbft](https://github.com/cometbft/cometbft) from v0.38.19 to [v0.38.20](https://github.com/cometbft/cometbft/releases/tag/v0.38.20)
-- Bump [github.com/cosmos/ibc-go/](https://github.com/cosmos/ibc-go) from 10.3.0 to [10.5.0](https://github.com/cosmos/ibc-go/releases/tag/v10.5.0)
+- Bump [cometbft](https://github.com/cometbft/cometbft) from 0.38.19 to 0.38.20 ([#3930](https://github.com/cosmos/gaia/pull/3930))
+- Bump [github.com/cosmos/cosmos-sdk](https://github.com/cosmos/cosmos-sdk) from 0.53.3 to 0.53.4 ([#3932](https://github.com/cosmos/gaia/pull/3932))
+- Bump [github.com/cosmos/ibc-go/](https://github.com/cosmos/ibc-go) from 10.3.0 to 10.5.0 ([#3932](https://github.com/cosmos/gaia/pull/3932))
 
 ## v25.2.0
 
@@ -22,7 +27,6 @@
 - Bump [slackapi/slack-github-action](https://github.com/slackapi/slack-github-action) from 1.27.0 to 2.1.1 ([#3830](https://github.com/cosmos/gaia/pull/3830))
 - Bump on-headers from 1.0.2 to 1.1.0 ([#3833](https://github.com/cosmos/gaia/pull/3833))
 - Bump compression from 1.8.0 to 1.8.1 ([#3833](https://github.com/cosmos/gaia/pull/3833))
-- Bump [github.com/cosmos/cosmos-sdk](https://github.com/cosmos/cosmos-sdk) from 0.53.3 to 0.53.4 ([#3837](https://github.com/cosmos/gaia/pull/3837))
 - Bump [github.com/prometheus/client_golang](https://github.com/prometheus/client_golang) from 1.22.0 to 1.23.0 ([#3838](https://github.com/cosmos/gaia/pull/3838))
 - Bump [docker/metadata-action](https://github.com/docker/metadata-action) from 5.7.0 to 5.8.0 ([#3836](https://github.com/cosmos/gaia/pull/3836))
 - Bump [github.com/spf13/pflag](https://github.com/spf13/pflag) from 1.0.6 to 1.0.7 ([#3839](https://github.com/cosmos/gaia/pull/3839))
@@ -32,7 +36,8 @@
 - Bump [docker/login-action](https://github.com/docker/login-action) from 3.4.0 to 3.5.0 ([#3842](https://github.com/cosmos/gaia/pull/3842))
 - Bump [actions/download-artifact](https://github.com/actions/download-artifact) from 4 to 5 ([#3843](https://github.com/cosmos/gaia/pull/3843))
 - Bump [actions/download-artifact](https://github.com/actions/download-artifact) from 5 to 6 ([#3882](https://github.com/cosmos/gaia/pull/3882))
-
+- Bump [github.com/CosmWasm/wasmd](https://github.com/CosmWasm/wasmd) from v0.60.1 to v0.60.2 ([#3888](https://github.com/cosmos/gaia/pull/3888))
+- 
 ## v25.1.0
 
 *July 8, 2025*


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Changelog updates in `main`:
- Adds the v25.3.0 release
- Removes the cosmos-sdk bump to v0.53.4 from the v25.2.0 entry 
- Adds the wasmd bump to v0.60.2 to the v25.2.0 entry

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct `docs:` prefix in the PR title
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

