### PR TITLE
ci: Replace Gaia-Runner-medium with depot runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       packages: write
       contents: write
-    runs-on: Gaia-Runner-medium
+    runs-on: depot-ubuntu-22.04-4
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           path: ./profile.out
 
   test-e2e:
-    runs-on: Gaia-Runner-medium
+    runs-on: depot-ubuntu-22.04-4
     timeout-minutes: 45
     steps:
       - uses: actions/setup-go@v5
@@ -102,7 +102,7 @@ jobs:
           name: "${{ github.sha }}-coverage"
 
   liveness-test:
-    runs-on: Gaia-Runner-medium
+    runs-on: depot-ubuntu-22.04-4
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Description

Replaces `Gaia-Runner-medium` with `depot-ubuntu-22.04-4` in the release and test GitHub Actions workflows.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

