### PR TITLE
ci: Fix upgrade on setup flag for gov test

### DIFF
--- a/tests/interchain/delegator/gov_test.go
+++ b/tests/interchain/delegator/gov_test.go
@@ -525,7 +525,6 @@ func TestGovModule(t *testing.T) {
 	s := &GovSuite{Suite: &delegator.Suite{Suite: chainsuite.NewSuite(chainsuite.SuiteConfig{
 		ChainSpec:      chainSpec,
 		UpgradeOnSetup: true,
-		CreateRelayer:  true,
 	})}}
 	suite.Run(t, s)
 }

--- a/tests/interchain/delegator/gov_test.go
+++ b/tests/interchain/delegator/gov_test.go
@@ -524,7 +524,7 @@ func TestGovModule(t *testing.T) {
 
 	s := &GovSuite{Suite: &delegator.Suite{Suite: chainsuite.NewSuite(chainsuite.SuiteConfig{
 		ChainSpec:      chainSpec,
-		UpgradeOnSetup: false,
+		UpgradeOnSetup: true,
 		CreateRelayer:  true,
 	})}}
 	suite.Run(t, s)


### PR DESCRIPTION
## Description

The interchaintest suite for the gov module has the upgrade on setup flag set to false, leading to a skipped upgrade during tests.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

