### PR TITLE
ci: Fix upgrade on setup flag for gov test (release/v26.x)

### DIFF
--- a/tests/interchain/delegator/gov_test.go
+++ b/tests/interchain/delegator/gov_test.go
@@ -524,8 +524,7 @@ func TestGovModule(t *testing.T) {
 
 	s := &GovSuite{Suite: &delegator.Suite{Suite: chainsuite.NewSuite(chainsuite.SuiteConfig{
 		ChainSpec:      chainSpec,
-		UpgradeOnSetup: false,
-		CreateRelayer:  true,
+		UpgradeOnSetup: true,
 	})}}
 	suite.Run(t, s)
 }


### PR DESCRIPTION
## Description

Fixes the upgrade on setup flag for the interchaintest gov suite in the `release/v26.x` branch.
This is a backport of PR [3956](https://github.com/cosmos/gaia/pull/3956/changes)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

