### PR TITLE
chore: Set up v26 backport for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,20 +24,11 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           {{ body }}
 
-  - name: Backport patches to the release/v25.x branch
+  - name: Backport patches to the release/v26.x branch
     conditions:
       - base=main
-      - label=A:backport/v25.x
+      - label=A:backport/v26.x
     actions:
       backport:
         branches:
-          - release/v25.x
-
-  - name: Backport patches to the release/v24.x branch
-    conditions:
-      - base=main
-      - label=A:backport/v24.x
-    actions:
-      backport:
-        branches:
-          - release/v24.x
+          - release/v26.x


### PR DESCRIPTION
## Description

Replace `release/v25.x` and `release/v24.x` targets with `release/v26.x`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

