### PR TITLE
docs: add v27.1.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # CHANGELOG
 
-## UNRELEASED
+## v27.1.0
+
+*March 13, 2026*
 
 ### FEATURES
 
 - Bump golang from 1.24 to 1.25 ([#3984](https://github.com/cosmos/gaia/pull/3984))
-
-### BUG-FIXES
 
 ### DEPENDENCIES
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,7 +18,7 @@ A governance gated upgrade occurs when an upgrade plan goes on chain through a s
 2. Wait for the node to stop at the upgrade height.
   * The log will display something like this:
     ```
-    ERR UPGRADE "v27.0.0" NEEDED at height: <UPGRADE_HEIGHT>: upgrade to v27.0.0 and applying upgrade "v27.0.0" at height:<UPGRADE_HEIGHT>
+    ERR UPGRADE "v27.1.0" NEEDED at height: <UPGRADE_HEIGHT>: upgrade to v27.1.0 and applying upgrade "v27.1.0" at height:<UPGRADE_HEIGHT>
     ```
 * If the node service remains active, you can stop it now.
 3. Replace the binary listed in the unit file with the new release.
@@ -28,17 +28,17 @@ A governance gated upgrade occurs when an upgrade plan goes on chain through a s
 
 1. Build or download the binary for the release you are upgrading to.
 2. Create a folder for the new binary in the relevant Cosmovisor directory.
-  * If the upgrade name is `v27.0.0`, you would place the binary under `<node home>/cosmovisor/upgrades/v27.0.0/bin/gaiad`:
+  * If the upgrade name is `v27.1.0`, you would place the binary under `<node home>/cosmovisor/upgrades/v27.1.0/bin/gaiad`:
     ```
     .
     ├── current -> genesis or upgrades/<name>
     ├── genesis
     │   └── bin
-    │       └── gaiad  # old: v26.0.0
+    │       └── gaiad  # old: v27.0.0
     └── upgrades
-        └── v27.0.0
+        └── v27.1.0
             └── bin
-                └── gaiad  # new: v27.0.0
+                └── gaiad  # new: v27.1.0
     ```
 3. Verify that Cosmovisor will use the binary you have prepared.
   * The Cosmovisor service should have the auto-download feature disabled. A sample Cosmovisor unit file will look like this:


### PR DESCRIPTION
## Description

**Changes will be merged to the release/v27.x` branch only**
* Add v27.1.0 to changelog
* Use v27.0.0 -> v27.1.0 upgrade path in upgrade instructions

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct `docs:` prefix in the PR title
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

