### PR TITLE
ci: disable arm64 builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,9 +165,8 @@ jobs:
       - name: Install New Gaiad
         run: |
           curl -LO https://github.com/CosmWasm/wasmvm/releases/download/v2.3.3/libwasmvm.x86_64.so
-          curl -LO https://github.com/CosmWasm/wasmvm/releases/download/v2.3.3/libwasmvm.aarch64.so
           uname -m
-          sudo cp "./libwasmvm.$(uname -m).so" /usr/lib/
+          sudo cp "./libwasmvm.x86_64.so" /usr/lib/
           make build
           cp ./build/gaiad ./build/gaiadnew
           go clean -modcache

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,41 +7,41 @@ env:
   - CGO_ENABLED=1
 
 builds:
-  - id: "gaiad-darwin-arm64"
-    main: ./cmd/gaiad
-    binary: gaiad
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
-    env:
-      - CC=oa64-clang
-      - CGO_CFLAGS=-D__BLST_PORTABLE__
-      - CGO_LDFLAGS=-L/lib
-    tags:
-      - netgo
-      - ledger
-      - static_wasm
-    flags:
-      - -trimpath
-      - -mod=readonly
-
-    ldflags:
-      # .Env.TM_VERSION is provided in the workflow runner environment -> see .github/workflows/release.yml
-      - -s -w
-      - -linkmode=external
-      - -X main.commit={{.Commit}}
-      - -X main.date={{ .CommitDate }}
-      - -X github.com/cosmos/cosmos-sdk/version.Name=gaia
-      - -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad
-      - -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
-      - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}
+  # arm64 is not supported by the wasm modules
+  # - id: "gaiad-darwin-arm64"
+  #   main: ./cmd/gaiad
+  #   binary: gaiad
+  #   goos:
+  #     - darwin
+  #   goarch:
+  #     - arm64
+  #   mod_timestamp: "{{ .CommitTimestamp }}"
+  #   hooks:
+  #     pre:
+  #       - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+  #   env:
+  #     - CC=oa64-clang
+  #     - CGO_CFLAGS=-D__BLST_PORTABLE__
+  #     - CGO_LDFLAGS=-L/lib
+  #   tags:
+  #     - netgo
+  #     - ledger
+  #     - static_wasm
+  #   flags:
+  #     - -trimpath
+  #     - -mod=readonly
+  #   ldflags:
+  #     # .Env.TM_VERSION is provided in the workflow runner environment -> see .github/workflows/release.yml
+  #     - -s -w
+  #     - -linkmode=external
+  #     - -X main.commit={{.Commit}}
+  #     - -X main.date={{ .CommitDate }}
+  #     - -X github.com/cosmos/cosmos-sdk/version.Name=gaia
+  #     - -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad
+  #     - -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }}
+  #     - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+  #     - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+  #     - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}
 
   - id: "gaiad-darwin-amd64"
     main: ./cmd/gaiad
@@ -118,11 +118,12 @@ builds:
   # - -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }}
 
 universal_binaries:
-  - id: gaiad-darwin-universal
-    ids:
-      - gaiad-darwin-arm64
-      - gaiad-darwin-amd64
-    replace: false
+  # arm64 is not supported by the wasm modules
+  # - id: gaiad-darwin-universal
+  #   ids:
+  #     - gaiad-darwin-arm64
+  #     - gaiad-darwin-amd64
+  #   replace: false
   # - id: gaiad-linux-universal
   # ids:
   # - gaiad-linux-amd64
@@ -144,9 +145,9 @@ archives:
   - format: binary
     name_template: "{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     builds:
-      - gaiad-darwin-arm64
+      # - gaiad-darwin-arm64 # arm64 is not supported by the wasm modules
       - gaiad-darwin-amd64
-      # - gaiad-linux-amd64
+      # - gaiad-linux-amd64 # muslc build is not available through GitHub Actions
     wrap_in_directory: false
     files:
       - none*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,9 @@ ENV CGO_CFLAGS=$CGO_CFLAGS
 
 # See https://github.com/CosmWasm/wasmvm/releases
 ARG WASMVM_VERSION=v2.3.3
-ADD https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 3e7846f80ef707d673eada84f4a57a4cc788edc6950c490108e963d2fb3280fc
 RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 097dccf8c71a28410e7bbe4cddaf506fadc1bda080cfd58fb0a4edeba8d5eb45
-RUN cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a
+RUN cp "/lib/libwasmvm_muslc.x86_64.a" /lib/libwasmvm_muslc.a
 
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,4 +29,4 @@ make install
 
 ## ⚡️ Download binaries
 
-Binaries for linux, darwin, and windows are available below.
+Binaries for linux and darwin are available below.

--- a/contrib/images/gaiad-env/Dockerfile
+++ b/contrib/images/gaiad-env/Dockerfile
@@ -9,11 +9,9 @@ RUN apk add --no-cache $PACKAGES
 
 # See https://github.com/CosmWasm/wasmvm/releases
 ARG WASMVM_VERSION=v2.3.3
-ADD https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 3e7846f80ef707d673eada84f4a57a4cc788edc6950c490108e963d2fb3280fc
 RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 097dccf8c71a28410e7bbe4cddaf506fadc1bda080cfd58fb0a4edeba8d5eb45
-RUN cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a
+RUN cp "/lib/libwasmvm_muslc.x86_64.a" /lib/libwasmvm_muslc.a
 
 COPY go.mod go.sum* ./
 RUN go mod download


### PR DESCRIPTION
## Description

* Disable the creation of arm64 builds for both darwin and linux.
* Remove "windows" from the release page template.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

