### PR TITLE
docs(service-providers): add third-party RPC latency benchmark reference

### DIFF
--- a/docs/docs/resources/service-providers.md
+++ b/docs/docs/resources/service-providers.md
@@ -32,6 +32,8 @@ There are four main technologies to consider to connect to the Cosmos Hub:
 - REST API: Use available endpoints for the REST Server.
 - GRPC: Connect to the Cosmos Hub using gRPC.
 
+For independent live latency measurements of public Cosmos Hub RPC endpoints across providers (Lava Network, Polkachu, Imperator, LavenderFive and others), see the [OpenChainBench Cosmos Hub RPC benchmark](https://openchainbench.com/benchmarks/cosmos-hub-rpc), probed every minute from three regions under a CC BY 4.0 license.
+
 ## Running a Full Node
 
 ### What is a Full Node?


### PR DESCRIPTION
Adds one paragraph to the "Connection Options" section of `docs/docs/resources/service-providers.md`, right after the existing list of connection technologies.

**Why this fits:**
- Service providers reading this page need to evaluate Cosmos Hub RPC endpoints for reliability and latency
- OpenChainBench measures public Cosmos Hub RPC providers (Lava Network, Polkachu, Imperator, LavenderFive, and others) continuously
- Cosmos Hub currently leads OpenChainBench's validator-yield benchmark, so third-party validation of the ecosystem is topically relevant

**What's added:**
- One paragraph (~2 sentences)
- Link to https://openchainbench.com/benchmarks/cosmos-hub-rpc

**About OpenChainBench:** independent open-source project measuring public RPC endpoint latency across 22+ chains (including Cosmos Hub) every minute from three regions. Data published under CC BY 4.0, Go harness open sourced on GitHub, no affiliation with any RPC provider.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.