### PR TITLE
ci: Use informalsystems/hermes image in e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,9 +70,6 @@ jobs:
       - name: Build Gaia Docker Image
         if: env.GIT_DIFF
         run: make docker-build-debug
-      - name: Build Hermes Docker Image
-        if: env.GIT_DIFF
-        run: make docker-build-hermes
       - name: Test E2E
         if: env.GIT_DIFF
         run: make test-e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ before each commit is available in the `contrib/githooks/` directory.
 ### Testing
 
 Tests can be executed by running `make run-tests` at the top level of the Gaia repository.
-For running the e2e tests, make sure to build the docker images by running `make docker-build-all`.
+For running the e2e tests, make sure to build the docker image by running `make docker-build-debug`.
 
 When testing a function under a variety of different inputs, we prefer to use
 [table driven tests](https://github.com/golang/go/wiki/TableDrivenTests).

--- a/Makefile
+++ b/Makefile
@@ -373,13 +373,6 @@ endif
 docker-build-debug:
 	@docker build -t cosmos/gaiad-e2e -f Dockerfile .
 
-# TODO: Push this to the Cosmos Dockerhub so we don't have to keep building it
-# in CI.
-docker-build-hermes:
-	@cd tests/e2e/docker; docker build -t ghcr.io/cosmos/hermes-e2e:1.0.0 -f hermes.Dockerfile .
-
-docker-build-all: docker-build-debug docker-build-hermes
-
 ###############################################################################
 ###                                Linting                                  ###
 ###############################################################################
@@ -436,7 +429,7 @@ test-docker-push: test-docker
 	@docker push ${TEST_DOCKER_REPO}:latest
 
 .PHONY: all build-linux install format lint draw-deps clean build \
-	docker-build-debug docker-build-hermes docker-build-all
+	docker-build-debug
 
 
 ###############################################################################

--- a/tests/e2e/docker/hermes.Dockerfile
+++ b/tests/e2e/docker/hermes.Dockerfile
@@ -1,9 +1,0 @@
-FROM --platform=linux/amd64 informalsystems/hermes:1.10.0 AS hermes-builder
-
-FROM --platform=linux/amd64 debian:buster-slim
-USER root
-
-COPY --from=hermes-builder /usr/bin/hermes /usr/local/bin/
-RUN chmod +x /usr/local/bin/hermes
-
-EXPOSE 3031

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -569,8 +569,8 @@ func (s *IntegrationTestSuite) runIBCRelayer() {
 	s.Resources.HermesResource, err = s.Resources.DkrPool.RunWithOptions(
 		&dockertest.RunOptions{
 			Name:       fmt.Sprintf("%s-%s-relayer", s.Resources.ChainA.ID, s.Resources.ChainB.ID),
-			Repository: "ghcr.io/cosmos/hermes-e2e",
-			Tag:        "1.0.0",
+			Repository: "ghcr.io/informalsystems/hermes",
+			Tag:        "1.13.1",
 			NetworkID:  s.Resources.DkrNet.Network.ID,
 			Mounts: []string{
 				fmt.Sprintf("%s/:/root/hermes", hermesCfgPath),


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

* `tests/e2e` now points directly at the same upstream image (`ghcr.io/informalsystems/hermes:1.13.1`) as `tests/interchain/chainsuite/relayer.go` in `tests/e2e/e2e_setup_test.go`
* Removed the `docker-build-hermes` Makefile target
* Removed `tests/e2e/docker/hermes.Dockerfile`
* Removed the `Build Hermes Docker Image` step from the test-e2e job in `.github/workflows/test.yml`
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Confirmed all author checklist items have been addressed
- [x] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

