### PR TITLE
chore: Add v28 backports to mergify

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,10 +154,10 @@ jobs:
       # the old gaiad binary version is hardcoded, need to be updated each major release.
       - name: Install Old Gaiad
         run: |
-          curl -LO https://github.com/cosmos/gaia/releases/download/v27.0.0/gaiad-v27.0.0-linux-amd64
-          chmod a+x gaiad-v27.0.0-linux-amd64
+          curl -LO https://github.com/cosmos/gaia/releases/download/v27.6.0/gaiad-v27.6.0-linux-amd64
+          chmod a+x gaiad-v27.6.0-linux-amd64
           mkdir build
-          mv ./gaiad-v27.0.0-linux-amd64 ./build/gaiadold
+          mv ./gaiad-v27.6.0-linux-amd64 ./build/gaiadold
         if: env.GIT_DIFF
       - name: Install New Gaiad
         run: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,14 @@ pull_request_rules:
         commit_message_format:
           title: pr-title
           body: pr-body
+  - name: Backport patches to the release/v28.x branch
+    conditions:
+      - base=main
+      - label=A:backport/v28.x
+    actions:
+      backport:
+        branches:
+          - release/v28.x
   - name: Backport patches to the release/v27.x branch
     conditions:
       - base=main
@@ -31,12 +39,3 @@ pull_request_rules:
       backport:
         branches:
           - release/v27.x
-
-  - name: Backport patches to the release/v26.x branch
-    conditions:
-      - base=main
-      - label=A:backport/v26.x
-    actions:
-      backport:
-        branches:
-          - release/v26.x

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,7 +18,7 @@ A governance gated upgrade occurs when an upgrade plan goes on chain through a s
 2. Wait for the node to stop at the upgrade height.
   * The log will display something like this:
     ```
-    ERR UPGRADE "v23.0.0" NEEDED at height: <UPGRADE_HEIGHT>: upgrade to v23.0.0 and applying upgrade "v23.0.0" at height:<UPGRADE_HEIGHT>
+    ERR UPGRADE "v28.0.0" NEEDED at height: <UPGRADE_HEIGHT>: upgrade to v28.0.0 and applying upgrade "v28.0.0" at height:<UPGRADE_HEIGHT>
     ```
 * If the node service remains active, you can stop it now.
 3. Replace the binary listed in the unit file with the new release.
@@ -28,17 +28,17 @@ A governance gated upgrade occurs when an upgrade plan goes on chain through a s
 
 1. Build or download the binary for the release you are upgrading to.
 2. Create a folder for the new binary in the relevant Cosmovisor directory.
-  * If the upgrade name is `v23.0.0`, you would place the binary under `<node home>/cosmovisor/upgrades/v23.0.0/bin/gaiad`:
+  * If the upgrade name is `v28.0.0`, you would place the binary under `<node home>/cosmovisor/upgrades/v28.0.0/bin/gaiad`:
     ```
     .
     ├── current -> genesis or upgrades/<name>
     ├── genesis
     │   └── bin
-    │       └── gaiad  # old: v22.3.0
+    │       └── gaiad  # old: v27.6.0
     └── upgrades
-        └── v23
+        └── v28.0.0
             └── bin
-                └── gaiad  # new: v23.0.0
+                └── gaiad  # new: v28.0.0
     ```
 3. Verify that Cosmovisor will use the binary you have prepared.
   * The Cosmovisor service should have the auto-download feature disabled. A sample Cosmovisor unit file will look like this:


### PR DESCRIPTION
## Description

* Add a rule in the mergify config to backport changes to `release/v28.x`.
* Update the upgrade instructions doc with the latest versions.
* Update the old version in the test.yml workflow 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/gaia/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [X] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

